### PR TITLE
Update README.md with use for `SuppliedSchema`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ features = ["derive"]
 [dependencies.serde_json]
 version = ">=0.8.0, <2.0"
 
+[dependencies.url]
+version = ">= 2.1.1"
+
 [dev-dependencies]
 mockito = "0.16.0"
 rdkafka = "0.20.0"

--- a/README.md
+++ b/README.md
@@ -135,7 +135,10 @@ fn get_future_record_from_struct<'a>(
 # Example using to post schema to schema registry
 
 ```rust
-use schema_registry_converter::schema_registry::SubjectNameStrategy::post_schema;
+use schema_registry_converter::schema_registry::{
+    SubjectNameStrategy::post_schema,
+    SuppliedSchema
+};
 
 fn main(){
     let heartbeat_schema = SuppliedSchema::new(r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#.into());

--- a/README.md
+++ b/README.md
@@ -136,13 +136,13 @@ fn get_future_record_from_struct<'a>(
 
 ```rust
 use schema_registry_converter::schema_registry::{
-    SubjectNameStrategy::post_schema,
+    post_schema,
     SuppliedSchema
 };
 
 fn main(){
     let heartbeat_schema = SuppliedSchema::new(r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#.into());
-    let result = post_schema("localhost:8081/subjects/test-value/versions");
+    let result = post_schema("localhost:8081/subjects/test-value/versions", heartbeat_schema);
 }
 
 ```


### PR DESCRIPTION
- Example in `README.md` for use of `post_schema` updated to show that
`SuppliedSchema` struct in example is also member of `schema_registry`
module.

Related to issue #16 
