### PR TITLE
Implement Fail Trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ version = ">= 1.0"
 [dependencies.curl]
 version = ">= 0.4"
 
+[dependencies.failure]
+version = ">= 0.1.6"
+
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@
 //!
 //! [avro-rs]: https://crates.io/crates/avro-rs
 
+#[macro_use] extern crate failure;
+
 pub mod schema_registry;
 
 use avro_rs::schema::Name;

--- a/src/schema_registry.rs
+++ b/src/schema_registry.rs
@@ -307,7 +307,7 @@ impl Handler for Collector {
 
 /// Error struct which makes it easy to know if the resulting error is also preserved in the cache
 /// or not. And whether trying it again might not cause an error.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Fail)]
 pub struct SRCError {
     error: String,
     side: Option<String>,


### PR DESCRIPTION
The [failure](https://docs.rs/failure/0.1.6/failure/) crate offers a simpler way to work with errors in Rust code.  The `Fail` trait, which can be derived, allows implementing types to be cast via `From` and `Into`, to the `Error` type also provided by `failure`.  This is especially helpful where a function returns `Result<S, E>` where `E: Fail`, because users can easily return `Result<S, failure::Error>` from their own functions, propagating out other errors implementing `Fail` with the `?` operator.

**Describe the solution you'd like**
Derive `Fail` on `SRCError`.

**Describe alternatives you've considered**
N/A

**Additional context**
N/A
