### PR TITLE
derive Clone for blocking::SrSettings

### DIFF
--- a/src/blocking/schema_registry.rs
+++ b/src/blocking/schema_registry.rs
@@ -20,7 +20,7 @@ use crate::schema_registry_common::{
 /// Settings used to do the calls to schema registry. For simple cases you can use `SrSettings::new`
 /// or the `SrSettingsBuilder`. But you can also use it directly so you can all the available
 /// settings from reqwest.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SrSettings {
     urls: Vec<String>,
     client: Client,


### PR DESCRIPTION
Thanks for building this crate! I noticed what I believe is a small oversight in the `SrSettings` implementation for `blocking`. 

Add `Clone` to the derive list for the `blocking::SrSettings` struct. This appears already in `async_impl::SrSettings` list of derived traits([source](https://github.com/gklijs/schema_registry_converter/blob/master/src/blocking/schema_registry.rs#L23)] so should be a desirable change.

If you have any additional thoughts or changes you'd like to see alongside this please let me know!