### PR TITLE
Add feature to switch TLS library used by `reqwest` lib [`native-tls`, `rustls`]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,16 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [features]
+native_tls = ["reqwest/native-tls"]
+rustls_tls = ["reqwest/rustls-tls"]
+
 avro = ["avro-rs"]
 blocking = ["reqwest/blocking"]
 json = ["url", "valico"]
 proto_decoder = ["bytes", "integer-encoding", "logos", "protofish"]
 proto_raw = ["integer-encoding", "logos"]
 kafka_test = []
-default = ["futures"]
+default = ["futures","native_tls"]
 
 [dependencies.byteorder]
 version = "^1.4"
@@ -29,6 +32,7 @@ version = "^0.1"
 
 [dependencies.reqwest]
 version = "^0.11"
+default-features = false
 features = ["json"]
 
 [dependencies.serde]


### PR DESCRIPTION
**Rationale:**
I am using this library in my project, as well as `reqwest` lib.  By default `reqwest` lib use `native-tls` for secure connections but it allows (via features) switch it to `rustls` (which I am sure you are aware of)
This PR is to provide same feature switch for this library. I made sure that default behavior doesn't change.
P.S. I have serious doubts about `native-tls` lib performance and I suspect memory leaks there. 

**Test results**
* unit test - Ok
* Integration test -Ok 
