### PR TITLE
Add 'easy' feature and easy encoders to easily work with async code w…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ blocking = ["reqwest/blocking"]
 json = ["url", "valico"]
 proto_decoder = ["bytes", "integer-encoding", "logos", "protofish"]
 proto_raw = ["integer-encoding", "logos"]
+easy = ["tokio"]
 kafka_test = []
 default = ["futures"]
 
@@ -66,6 +67,11 @@ optional = true
 version = "^2"
 optional = true
 
+[dependencies.tokio]
+version = "^1.2.0"
+features = ["macros"]
+optional = true
+
 [dependencies.valico]
 version = "^3.5"
 optional = true
@@ -75,7 +81,6 @@ mockito = "^0.29.0"
 rdkafka = { version = "^0.25.0", features = ["cmake-build"] }
 rand = "^0.8.3"
 test_utils = {path = "test_utils"}
-tokio = { version = "^1.2.0", features = ["macros"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/async_impl/avro.rs
+++ b/src/async_impl/avro.rs
@@ -936,7 +936,19 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(bytes, vec![0, 0, 0, 0, 3, 6])
+        assert_eq!(bytes, vec![0, 0, 0, 0, 3, 6]);
+
+        let value_strategy =
+            SubjectNameStrategy::TopicNameStrategy(String::from("heartbeat"), true);
+        let bytes = encoder
+            .encode(
+                vec![("name", Value::String(String::from("x")))],
+                value_strategy,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(bytes, vec![0, 0, 0, 0, 4, 2, 120])
     }
 
     #[tokio::test]

--- a/src/async_impl/easy_json.rs
+++ b/src/async_impl/easy_json.rs
@@ -1,0 +1,119 @@
+use crate::async_impl::json::{DecodeResult, JsonDecoder, JsonEncoder};
+use crate::async_impl::schema_registry::SrSettings;
+use crate::error::SRCError;
+use crate::schema_registry_common::SubjectNameStrategy;
+use serde_json::Value;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// A decoder used to transform bytes to a [DecodeResult], its much like [JsonDecoder] but includes a mutex, so the user does not need to care about mutability.
+pub struct EasyJsonDecoder {
+    decoder: Arc<Mutex<JsonDecoder<'static>>>,
+}
+
+impl EasyJsonDecoder {
+    pub fn new(sr_settings: SrSettings) -> EasyJsonDecoder {
+        let decoder = Arc::new(Mutex::new(JsonDecoder::new(sr_settings)));
+        EasyJsonDecoder { decoder }
+    }
+    pub async fn decode(&self, bytes: Option<&[u8]>) -> Result<Option<DecodeResult>, SRCError> {
+        let mut lock = self.decoder.lock().await;
+        lock.decode(bytes).await
+    }
+}
+
+/// An encoder used to transform a [Value] to bytes, its much like [JsonEncoder] but includes a mutex, so the user does not need to care about mutability.
+pub struct EasyJsonEncoder {
+    encoder: Arc<Mutex<JsonEncoder<'static>>>,
+}
+
+impl EasyJsonEncoder {
+    pub fn new(sr_settings: SrSettings) -> EasyJsonEncoder {
+        let encoder = Arc::new(Mutex::new(JsonEncoder::new(sr_settings)));
+        EasyJsonEncoder { encoder }
+    }
+    pub async fn encode(
+        &self,
+        value: &Value,
+        subject_name_strategy: SubjectNameStrategy,
+    ) -> Result<Vec<u8>, SRCError> {
+        let mut lock = self.encoder.lock().await;
+        lock.encode(value, subject_name_strategy).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::async_impl::easy_json::{EasyJsonDecoder, EasyJsonEncoder};
+    use crate::async_impl::json::validate;
+    use crate::async_impl::schema_registry::SrSettings;
+    use crate::schema_registry_common::{get_payload, SubjectNameStrategy};
+    use mockito::{mock, server_address};
+    use serde_json::Value;
+    use std::fs::{read_to_string, File};
+    use test_utils::{get_json_body, json_result_java_bytes, json_result_schema};
+
+    #[tokio::test]
+    async fn test_decoder_default() {
+        let result_value: String = read_to_string("tests/schema/result-example.json")
+            .unwrap()
+            .parse()
+            .unwrap();
+        let _m = mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(&get_json_body(json_result_schema(), 7))
+            .create();
+
+        let sr_settings = SrSettings::new(format!("http://{}", server_address()));
+        let decoder = EasyJsonDecoder::new(sr_settings);
+        let message = decoder
+            .decode(Some(&*get_payload(7, result_value.into_bytes())))
+            .await
+            .unwrap()
+            .unwrap();
+        validate(message.schema, &message.value).unwrap();
+        assert_eq!(
+            "string",
+            message
+                .value
+                .as_object()
+                .unwrap()
+                .get("down")
+                .unwrap()
+                .as_str()
+                .unwrap()
+        );
+        assert_eq!(
+            "STRING",
+            message
+                .value
+                .as_object()
+                .unwrap()
+                .get("up")
+                .unwrap()
+                .as_str()
+                .unwrap()
+        )
+    }
+
+    #[tokio::test]
+    async fn test_encode_default() {
+        let _m = mock("GET", "/subjects/testresult-value/versions/latest")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(&get_json_body(json_result_schema(), 10))
+            .create();
+
+        let sr_settings = SrSettings::new(format!("http://{}", server_address()));
+        let encoder = EasyJsonEncoder::new(sr_settings);
+        let strategy = SubjectNameStrategy::TopicNameStrategy(String::from("testresult"), false);
+        let result_example: Value =
+            serde_json::from_reader(File::open("tests/schema/result-example.json").unwrap())
+                .unwrap();
+
+        let encoded_data = encoder.encode(&result_example, strategy).await.unwrap();
+
+        assert_eq!(encoded_data, json_result_java_bytes())
+    }
+}

--- a/src/async_impl/easy_proto_decoder.rs
+++ b/src/async_impl/easy_proto_decoder.rs
@@ -1,0 +1,53 @@
+use crate::async_impl::proto_decoder::ProtoDecoder;
+use crate::async_impl::schema_registry::SrSettings;
+use crate::error::SRCError;
+use protofish::Value;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// A decoder used to transform bytes to a [Value], its much like [ProtoDecoder] but includes a mutex, so the user does not need to care about mutability.
+/// The mean use of this way of decoding is if you don't know the format at compile time.
+/// If you do know the format it's better to use the ProtoRawDecoder, and use a different library to deserialize just the proto bytes.
+pub struct EasyProtoDecoder {
+    decoder: Arc<Mutex<ProtoDecoder<'static>>>,
+}
+
+impl EasyProtoDecoder {
+    pub fn new(sr_settings: SrSettings) -> EasyProtoDecoder {
+        let decoder = Arc::new(Mutex::new(ProtoDecoder::new(sr_settings)));
+        EasyProtoDecoder { decoder }
+    }
+    pub async fn decode(&self, bytes: Option<&[u8]>) -> Result<Value, SRCError> {
+        let mut lock = self.decoder.lock().await;
+        lock.decode(bytes).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::async_impl::easy_proto_decoder::EasyProtoDecoder;
+    use crate::async_impl::schema_registry::SrSettings;
+    use mockito::{mock, server_address};
+    use protofish::Value;
+    use test_utils::{get_proto_body, get_proto_hb_101, get_proto_hb_schema};
+
+    #[tokio::test]
+    async fn test_decoder_default() {
+        let _m = mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(&get_proto_body(get_proto_hb_schema(), 1))
+            .create();
+
+        let sr_settings = SrSettings::new(format!("http://{}", server_address()));
+        let decoder = EasyProtoDecoder::new(sr_settings);
+        let heartbeat = decoder.decode(Some(get_proto_hb_101())).await.unwrap();
+
+        let message = match heartbeat {
+            Value::Message(x) => *x,
+            v => panic!("Other value: {:?} than expected Message", v),
+        };
+
+        assert_eq!(Value::UInt64(101u64), message.fields[0].value)
+    }
+}

--- a/src/async_impl/easy_proto_raw.rs
+++ b/src/async_impl/easy_proto_raw.rs
@@ -1,0 +1,132 @@
+use crate::async_impl::proto_raw::{ProtoRawDecoder, ProtoRawEncoder, RawDecodeResult};
+use crate::async_impl::schema_registry::SrSettings;
+use crate::error::SRCError;
+use crate::schema_registry_common::SubjectNameStrategy;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// A decoder used to transform bytes to a [RawDecodeResult], its much like [ProtoRawDecoder] but includes a mutex, so the user does not need to care about mutability.
+/// You can use the bytes from the result to create a proto object.
+pub struct EasyProtoRawDecoder {
+    decoder: Arc<Mutex<ProtoRawDecoder<'static>>>,
+}
+
+impl EasyProtoRawDecoder {
+    pub fn new(sr_settings: SrSettings) -> EasyProtoRawDecoder {
+        let decoder = Arc::new(Mutex::new(ProtoRawDecoder::new(sr_settings)));
+        EasyProtoRawDecoder { decoder }
+    }
+    pub async fn decode(&self, bytes: Option<&[u8]>) -> Result<Option<RawDecodeResult>, SRCError> {
+        let mut lock = self.decoder.lock().await;
+        lock.decode(bytes).await
+    }
+}
+
+/// An encoder used to transform the proto bytes to bytes compatible with confluent schema registry, its much like [ProtoRawEncoder] but includes a mutex, so the user does not need to care about mutability.
+/// This wil just add the magic byte, schema reference, and message reference. The bytes should already be valid proto bytes for the schema used.
+/// When a schema with multiple messages is used the full_name needs to be supplied to properly encode the message reference.
+pub struct EasyProtoRawEncoder {
+    encoder: Arc<Mutex<ProtoRawEncoder<'static>>>,
+}
+
+impl EasyProtoRawEncoder {
+    pub fn new(sr_settings: SrSettings) -> EasyProtoRawEncoder {
+        let encoder = Arc::new(Mutex::new(ProtoRawEncoder::new(sr_settings)));
+        EasyProtoRawEncoder { encoder }
+    }
+    pub async fn encode(
+        &self,
+        bytes: &[u8],
+        full_name: &str,
+        subject_name_strategy: SubjectNameStrategy,
+    ) -> Result<Vec<u8>, SRCError> {
+        let mut lock = self.encoder.lock().await;
+        lock.encode(bytes, full_name, subject_name_strategy).await
+    }
+    pub async fn encode_single_message(
+        &self,
+        bytes: &[u8],
+        subject_name_strategy: SubjectNameStrategy,
+    ) -> Result<Vec<u8>, SRCError> {
+        let mut lock = self.encoder.lock().await;
+        lock.encode_single_message(bytes, subject_name_strategy)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::async_impl::easy_proto_raw::{EasyProtoRawDecoder, EasyProtoRawEncoder};
+    use crate::async_impl::schema_registry::SrSettings;
+    use crate::schema_registry_common::SubjectNameStrategy;
+    use mockito::{mock, server_address};
+    use test_utils::{
+        get_proto_body, get_proto_hb_101, get_proto_hb_101_only_data, get_proto_hb_schema,
+    };
+
+    #[tokio::test]
+    async fn test_decoder_default() {
+        let _m = mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+
+        let sr_settings = SrSettings::new(format!("http://{}", server_address()));
+        let decoder = EasyProtoRawDecoder::new(sr_settings);
+        let raw_result = decoder
+            .decode(Some(get_proto_hb_101()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(raw_result.bytes, get_proto_hb_101_only_data());
+        assert_eq!(raw_result.full_name, "nl.openweb.data.Heartbeat")
+    }
+
+    #[tokio::test]
+    async fn test_encode_default() {
+        let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+
+        let sr_settings = SrSettings::new(format!("http://{}", server_address()));
+        let encoder = EasyProtoRawEncoder::new(sr_settings);
+        let strategy =
+            SubjectNameStrategy::RecordNameStrategy(String::from("nl.openweb.data.Heartbeat"));
+
+        let encoded_data = encoder
+            .encode(
+                get_proto_hb_101_only_data(),
+                "nl.openweb.data.Heartbeat",
+                strategy,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(encoded_data, get_proto_hb_101())
+    }
+
+    #[tokio::test]
+    async fn test_encode_single_message() {
+        let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+
+        let sr_settings = SrSettings::new(format!("http://{}", server_address()));
+        let encoder = EasyProtoRawEncoder::new(sr_settings);
+        let strategy =
+            SubjectNameStrategy::RecordNameStrategy(String::from("nl.openweb.data.Heartbeat"));
+
+        let encoded_data = encoder
+            .encode_single_message(get_proto_hb_101_only_data(), strategy)
+            .await
+            .unwrap();
+
+        assert_eq!(encoded_data, get_proto_hb_101())
+    }
+}

--- a/src/async_impl/mod.rs
+++ b/src/async_impl/mod.rs
@@ -1,5 +1,13 @@
 #[cfg(feature = "avro")]
 pub mod avro;
+#[cfg(all(feature = "easy", feature = "avro"))]
+pub mod easy_avro;
+#[cfg(all(feature = "easy", feature = "json"))]
+pub mod easy_json;
+#[cfg(all(feature = "easy", feature = "proto_decoder"))]
+pub mod easy_proto_decoder;
+#[cfg(all(feature = "easy", feature = "proto_raw"))]
+pub mod easy_proto_raw;
 #[cfg(feature = "json")]
 pub mod json;
 #[cfg(feature = "proto_decoder")]

--- a/src/async_impl/proto_raw.rs
+++ b/src/async_impl/proto_raw.rs
@@ -19,6 +19,8 @@ use futures::FutureExt;
 /// bytes. Ideally you want to make sure the bytes are based on the exact schema used for encoding
 /// but you need a protobuf struct that has introspection to make that work, and both protobuf and
 /// prost don't support that at the moment.
+/// This wil just add the magic byte, schema reference, and message reference. The bytes should already be valid proto bytes for the schema used.
+/// When a schema with multiple messages is used the full_name needs to be supplied to properly encode the message reference.
 #[derive(Debug)]
 pub struct ProtoRawEncoder<'a> {
     sr_settings: SrSettings,

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -115,8 +115,8 @@ impl Default for Atype {
 
 pub type Uuid = [u8; 16];
 
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(default)]
 pub struct ConfirmAccountCreation {
     pub id: Uuid,
     pub a_type: Atype,


### PR DESCRIPTION
…ithout having to worry about mutability, while still using the cache.

Fixes https://github.com/gklijs/schema_registry_converter/issues/54