### PR TITLE
Non static lifetime for encode method

### DIFF
--- a/src/avro_common.rs
+++ b/src/avro_common.rs
@@ -107,9 +107,9 @@ fn to_bytes(avro_schema: &AvroSchema, record: Value) -> Result<Vec<u8>, SRCError
 
 /// Using the schema with a vector of values the values will be correctly deserialized according to
 /// the avro specification.
-pub(crate) fn values_to_bytes(
+pub(crate) fn values_to_bytes<'b>(
     avro_schema: &AvroSchema,
-    values: Vec<(&'static str, Value)>,
+    values: Vec<(&str, Value)>,
 ) -> Result<Vec<u8>, SRCError> {
     let mut record = match Record::new(&avro_schema.parsed) {
         Some(v) => v,


### PR DESCRIPTION
Currently the encode method for both blocking and async_api requires a &str with static lifetime. The problem with using static lifetimes is that the str must be known at compile time, so this limits to generate records with fields discovered at runtime.

This commit relaxes the static lifetime to match the lifetime of the referenced object allowing to use also field names discovered at runtime. This commit do not impact on the behavior and performance of the already existing static lifetimes, as static lifetimes are allowed also, as they live during the whole execution of the process.

I have checked that the `record.put` in the `avro-rs` crate does not requires the static lifetime limitation, so it is safe to do this change.

This pull request add also two tests to check that this functionality works:
- async_impl::avro::tests::test_encode_key_and_value_with_non_static_lifetime
- blocking::avro::test_encode_key_and_value_with_non_static_lifetime