### PR TITLE
WIP: async avro impl: add a fast and strict FastAvroDecoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,13 @@ json = ["url", "valico"]
 proto_decoder = ["bytes", "integer-encoding", "logos", "protofish"]
 proto_raw = ["integer-encoding", "logos"]
 easy = ["tokio"]
+fast = ["dashmap"]
 kafka_test = []
 default = ["futures","native_tls"]
+
+[dependencies.dashmap]
+version = "^4.0"
+optional = true
 
 [dependencies.byteorder]
 version = "^1.4"


### PR DESCRIPTION
this avro decoder is (way) faster than the EasyAvro implementation
because its cache uses a DashMap instead of a lock hungry Mutex

see: https://github.com/gklijs/schema_registry_converter/discussions/67

---

This PR is intended as a demonstration of what I'm discussing in #67 .