### PR TITLE
Update avro to v0.16, fix tokio test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ features = ["derive"]
 version = "^1.0"
 
 [dependencies.apache-avro]
-version = "^0.14"
+version = "^0.16"
 optional = true
 
 [dependencies.bytes]
@@ -85,6 +85,7 @@ mockito = "^0.31.0"
 rdkafka = { version = "^0.29.0", features = ["cmake-build"] }
 rand = "^0.8.5"
 test_utils = {path = "test_utils"}
+tokio = { version = "^1.32.0", features = ["macros"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/avro_common.rs
+++ b/src/avro_common.rs
@@ -155,7 +155,7 @@ pub(crate) fn item_to_bytes(
 
 pub(crate) fn get_name(schema: &Schema) -> Option<Name> {
     match schema {
-        Schema::Record { name: n, .. } => Some(n.clone()),
+        Schema::Record(schema) => Some(schema.name.clone()),
         _ => None,
     }
 }


### PR DESCRIPTION
Ensures easy compat with latest version of the avro crate. Also add missing tokio dev-dependency, allowing async schema_registry test to run.