### PR TITLE
Housekeeping & exposing get_schema_and_id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ proto_decoder = ["bytes", "integer-encoding", "logos", "protofish"]
 proto_raw = ["integer-encoding", "logos"]
 easy = ["tokio"]
 kafka_test = []
-default = ["futures","native_tls"]
+default = ["futures", "native_tls"]
 
 [dependencies.byteorder]
 version = "^1.4"
@@ -84,7 +84,7 @@ optional = true
 mockito = "^0.31.0"
 rdkafka = { version = "^0.29.0", features = ["cmake-build"] }
 rand = "^0.8.5"
-test_utils = {path = "test_utils"}
+test_utils = { path = "test_utils" }
 tokio = { version = "^1.32.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/src/async_impl/avro.rs
+++ b/src/async_impl/avro.rs
@@ -177,7 +177,7 @@ impl<'a> AvroDecoder<'a> {
                 value: Value::Null,
             }),
             BytesResult::Valid(id, bytes) => self.deserialize(id, &bytes).await,
-            BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(&*format!(
+            BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(&format!(
                 "Invalid bytes {:?}",
                 bytes
             ))),
@@ -214,7 +214,7 @@ impl<'a> AvroDecoder<'a> {
                 Ok(v) => Ok(Some(v)),
                 Err(e) => Err(e),
             },
-            BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(&*format!(
+            BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(&format!(
                 "Invalid bytes {:?}",
                 bytes
             ))),
@@ -577,13 +577,13 @@ async fn to_avro_schema(
     match registered_schema.schema_type {
         SchemaType::Avro => (),
         t => {
-            return Err(SRCError::non_retryable_without_cause(&*format!(
+            return Err(SRCError::non_retryable_without_cause(&format!(
                 "type {:?}, is not supported",
                 t
             )));
         }
     }
-    let main_schema = match serde_json::from_str(&*registered_schema.schema) {
+    let main_schema = match serde_json::from_str(&registered_schema.schema) {
         Ok(v) => {
             match add_references(sr_settings, v, registered_schema.references.as_slice()).await {
                 Ok(u) => u,
@@ -605,7 +605,7 @@ async fn to_avro_schema(
         })),
         Err(e) => Err(SRCError::non_retryable_with_cause(
             e,
-            &*format!(
+            &format!(
                 "Supplied raw value {:?} cant be turned into a Schema",
                 registered_schema.schema
             ),
@@ -626,16 +626,16 @@ fn add_references<'a>(
                 Err(e) => {
                     return Err(SRCError::non_retryable_with_cause(
                         e,
-                        &*format!("problem with reference {:?}", r),
+                        &format!("problem with reference {:?}", r),
                     ));
                 }
             };
-            let child: value::Value = match serde_json::from_str(&*registered_schema.schema) {
+            let child: value::Value = match serde_json::from_str(&registered_schema.schema) {
                 Ok(v) => v,
                 Err(e) => {
                     return Err(SRCError::non_retryable_with_cause(
                         e,
-                        &*format!("problem serializing {}", registered_schema.schema),
+                        &format!("problem serializing {}", registered_schema.schema),
                     ));
                 }
             };

--- a/src/async_impl/avro.rs
+++ b/src/async_impl/avro.rs
@@ -357,12 +357,12 @@ impl<'a> AvroEncoder<'a> {
     /// let sr_settings = SrSettings::new(format!("http://{}", server_address()));
     /// let encoder = AvroEncoder::new(sr_settings);
     ///
-    /// let strategy = SubjectNameStrategy::TopicRecordNameStrategyWithSchema(String::from("hb"), Box::from(SuppliedSchema {
+    /// let strategy = SubjectNameStrategy::TopicRecordNameStrategyWithSchema(String::from("hb"), SuppliedSchema {
     ///                 name: Some(String::from("nl.openweb.data.Heartbeat")),
     ///                 schema_type: SchemaType::Avro,
     ///                 schema: String::from(r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#),
     ///                 references: vec![],
-    ///             }));
+    ///             });
     /// let bytes = encoder.encode(vec![("beat", Value::Long(3))], strategy).await;
     /// assert_eq!(bytes, Ok(vec![0, 0, 0, 0, 23, 6]));
     /// # Ok(())

--- a/src/async_impl/easy_avro.rs
+++ b/src/async_impl/easy_avro.rs
@@ -1,8 +1,11 @@
-use crate::async_impl::avro::{AvroDecoder, AvroEncoder};
 use crate::async_impl::schema_registry::SrSettings;
 use crate::avro_common::{DecodeResult, DecodeResultWithSchema};
 use crate::error::SRCError;
 use crate::schema_registry_common::SubjectNameStrategy;
+use crate::{
+    async_impl::avro::{AvroDecoder, AvroEncoder},
+    avro_common::AvroSchema,
+};
 use apache_avro::types::Value;
 use serde::Serialize;
 use std::sync::Arc;
@@ -40,7 +43,7 @@ impl EasyAvroEncoder {
     }
     pub async fn encode(
         &self,
-        values: Vec<(&'static str, Value)>,
+        values: Vec<(&str, Value)>,
         subject_name_strategy: SubjectNameStrategy,
     ) -> Result<Vec<u8>, SRCError> {
         self.encoder.encode(values, subject_name_strategy).await
@@ -52,6 +55,15 @@ impl EasyAvroEncoder {
     ) -> Result<Vec<u8>, SRCError> {
         self.encoder
             .encode_struct(item, subject_name_strategy)
+            .await
+    }
+    pub async fn get_schema_and_id(
+        &self,
+        key: &str,
+        subject_name_strategy: SubjectNameStrategy,
+    ) -> Result<Arc<AvroSchema>, SRCError> {
+        self.encoder
+            .get_schema_and_id(key, subject_name_strategy)
             .await
     }
 }

--- a/src/async_impl/easy_json.rs
+++ b/src/async_impl/easy_json.rs
@@ -59,7 +59,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 7))
+            .with_body(get_json_body(json_result_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -99,7 +99,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));

--- a/src/async_impl/easy_proto_decoder.rs
+++ b/src/async_impl/easy_proto_decoder.rs
@@ -40,7 +40,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 1))
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -60,7 +60,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 1))
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));

--- a/src/async_impl/easy_proto_raw.rs
+++ b/src/async_impl/easy_proto_raw.rs
@@ -68,7 +68,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -88,7 +88,7 @@ mod tests {
         let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -113,7 +113,7 @@ mod tests {
         let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));

--- a/src/async_impl/json.rs
+++ b/src/async_impl/json.rs
@@ -174,7 +174,7 @@ impl<'a> JsonDecoder<'a> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
             BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, &bytes).await?)),
-            BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(&*format!(
+            BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(&format!(
                 "Invalid bytes: {:?}",
                 i
             ))),
@@ -235,9 +235,9 @@ impl<'a> JsonDecoder<'a> {
 }
 
 fn reference_url(rr: &RegisteredReference) -> Result<Url, SRCError> {
-    match Url::from_str(&*rr.name) {
+    match Url::from_str(&rr.name) {
         Ok(v) => Ok(v),
-        Err(e) => Err(SRCError::non_retryable_with_cause(e, &*format!("reference schema with subject {} and version {} has invalid id {}, it has to be a fully qualified url", rr.subject, rr.version, rr.name)))
+        Err(e) => Err(SRCError::non_retryable_with_cause(e, &format!("reference schema with subject {} and version {} has invalid id {}, it has to be a fully qualified url", rr.subject, rr.version, rr.name)))
     }
 }
 
@@ -265,7 +265,7 @@ fn to_json_schema(
             .into_iter()
             .collect();
         let references = refs?;
-        let schema: Value = to_value(&*registered_schema.schema)?;
+        let schema: Value = to_value(&registered_schema.schema)?;
         let url = match optional_url {
             Some(v) => v,
             None => main_url(&schema, sr_settings, registered_schema.id),
@@ -309,7 +309,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -329,7 +329,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema_with_id(), 10))
+            .with_body(get_json_body(json_result_schema_with_id(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -359,7 +359,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let encoded_data = encoder.encode(&result_example, strategy.clone()).await;
@@ -380,7 +380,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 7))
+            .with_body(get_json_body(json_result_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -435,7 +435,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 7))
+            .with_body(get_json_body(json_result_schema(), 7))
             .create();
 
         let error = decoder
@@ -460,7 +460,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/10?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -500,7 +500,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/10?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -533,7 +533,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/5?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body_with_reference(
+            .with_body(get_json_body_with_reference(
                 json_test_ref_schema(),
                 5,
                 json_get_result_references(),
@@ -542,7 +542,7 @@ mod tests {
         let _m = mock("GET", "/subjects/result.json/versions/1")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 4))
+            .with_body(get_json_body(json_result_schema(), 4))
             .create();
 
         let value = decoder.decode(Some(&bytes)).await.unwrap().unwrap().value;
@@ -572,7 +572,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/5?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body_with_reference(
+            .with_body(get_json_body_with_reference(
                 json_test_ref_schema(),
                 5,
                 json_get_result_references(),
@@ -581,7 +581,7 @@ mod tests {
         let _m = mock("GET", "/subjects/result.json/versions/1")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(&json_result_schema()[0..30], 4))
+            .with_body(get_json_body(&json_result_schema()[0..30], 4))
             .create();
 
         let error = decoder.decode(Some(&bytes)).await.unwrap_err();
@@ -616,7 +616,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/5?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body_with_reference(
+            .with_body(get_json_body_with_reference(
                 json_test_ref_schema(),
                 5,
                 json_get_result_references(),
@@ -625,7 +625,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body_with_reference(
+            .with_body(get_json_body_with_reference(
                 json_test_ref_schema(),
                 7,
                 json_get_result_references(),
@@ -634,7 +634,7 @@ mod tests {
         let _m = mock("GET", "/subjects/result.json/versions/1")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 4))
+            .with_body(get_json_body(json_result_schema(), 4))
             .create();
 
         let value = decoder
@@ -686,7 +686,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -709,7 +709,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_test_ref_schema(), 10))
+            .with_body(get_json_body(json_test_ref_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));

--- a/src/async_impl/json.rs
+++ b/src/async_impl/json.rs
@@ -16,7 +16,7 @@ use crate::async_impl::schema_registry::{
 use crate::error::SRCError;
 use crate::json_common::{fetch_fallback, fetch_id, handle_validation, to_bytes, to_value};
 use crate::schema_registry_common::{
-    get_bytes_result, get_subject, BytesResult, RegisteredReference, RegisteredSchema, SchemaType,
+    get_bytes_result, BytesResult, RegisteredReference, RegisteredSchema, SchemaType,
     SubjectNameStrategy,
 };
 
@@ -56,7 +56,7 @@ impl<'a> JsonEncoder<'a> {
         value: &Value,
         subject_name_strategy: SubjectNameStrategy,
     ) -> Result<Vec<u8>, SRCError> {
-        let key = get_subject(&subject_name_strategy)?;
+        let key = subject_name_strategy.get_subject()?;
         let schema = &*self.get_schema(key, subject_name_strategy).await?;
         let id = schema.id;
         validate(schema.clone(), value)?;

--- a/src/async_impl/proto_decoder.rs
+++ b/src/async_impl/proto_decoder.rs
@@ -235,7 +235,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 1))
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -255,7 +255,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 1))
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -282,7 +282,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 1))
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
             .create();
 
         let error = decoder.decode(Some(get_proto_hb_101())).await.unwrap_err();
@@ -305,7 +305,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/6?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body_with_reference(
+            .with_body(get_proto_body_with_reference(
                 get_proto_complex(),
                 2,
                 get_proto_complex_references(),
@@ -315,7 +315,7 @@ mod tests {
         let _m = mock("GET", "/subjects/result.proto/versions/1")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_result(), 1))
+            .with_body(get_proto_body(get_proto_result(), 1))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));

--- a/src/async_impl/proto_raw.rs
+++ b/src/async_impl/proto_raw.rs
@@ -109,7 +109,7 @@ impl<'a> ProtoRawEncoder<'a> {
                     match get_schema_by_subject(&sr_settings, &subject_name_strategy).await {
                         Ok(registered_schema) => Ok(Arc::new(EncodeContext {
                             id: registered_schema.id,
-                            resolver: IndexResolver::new(&*registered_schema.schema),
+                            resolver: IndexResolver::new(&registered_schema.schema),
                         })),
                         Err(e) => Err(e.into_cache()),
                     }
@@ -158,7 +158,7 @@ impl<'a> ProtoRawDecoder<'a> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
             BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, &bytes).await?)),
-            BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(&*format!(
+            BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(&format!(
                 "Invalid bytes {:?}",
                 i
             ))),
@@ -239,7 +239,7 @@ mod tests {
         let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -264,7 +264,7 @@ mod tests {
         let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -285,7 +285,7 @@ mod tests {
         let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_complex(), 7))
+            .with_body(get_proto_body(get_proto_complex(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -318,7 +318,7 @@ mod tests {
         let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let error = encoder
@@ -350,7 +350,7 @@ mod tests {
         let _m = mock("POST", "/subjects/result.proto/versions")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_result(), 5))
+            .with_body(get_proto_body(get_proto_result(), 5))
             .create();
 
         let _m = mock("POST", "/subjects/result.proto?deleted=false")
@@ -362,7 +362,7 @@ mod tests {
         let _m = mock("POST", "/subjects/test.proto/versions")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_result(), 6))
+            .with_body(get_proto_body(get_proto_result(), 6))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -408,7 +408,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -434,7 +434,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let error = decoder.decode(Some(get_proto_hb_101())).await.unwrap_err();
@@ -457,7 +457,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/6?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body_with_reference(
+            .with_body(get_proto_body_with_reference(
                 get_proto_complex(),
                 2,
                 get_proto_complex_references(),
@@ -467,7 +467,7 @@ mod tests {
         let _m = mock("GET", "/subjects/result.proto/versions/1")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_result(), 1))
+            .with_body(get_proto_body(get_proto_result(), 1))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));

--- a/src/async_impl/proto_raw.rs
+++ b/src/async_impl/proto_raw.rs
@@ -7,7 +7,7 @@ use crate::proto_raw_common::{
 };
 use crate::proto_resolver::{resolve_name, to_index_and_data, IndexResolver};
 use crate::schema_registry_common::{
-    get_bytes_result, get_subject, BytesResult, RegisteredSchema, SchemaType, SubjectNameStrategy,
+    get_bytes_result, BytesResult, RegisteredSchema, SchemaType, SubjectNameStrategy,
 };
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
@@ -54,7 +54,7 @@ impl<'a> ProtoRawEncoder<'a> {
         full_name: &str,
         subject_name_strategy: SubjectNameStrategy,
     ) -> Result<Vec<u8>, SRCError> {
-        let key = get_subject(&subject_name_strategy)?;
+        let key = subject_name_strategy.get_subject()?;
         let encode_context = self
             .get_encoding_context(key, subject_name_strategy)
             .await?;
@@ -68,7 +68,7 @@ impl<'a> ProtoRawEncoder<'a> {
         bytes: &[u8],
         subject_name_strategy: SubjectNameStrategy,
     ) -> Result<Vec<u8>, SRCError> {
-        let key = get_subject(&subject_name_strategy)?;
+        let key = subject_name_strategy.get_subject()?;
         let encode_context = self
             .get_encoding_context(key, subject_name_strategy)
             .await?;
@@ -379,8 +379,7 @@ mod tests {
             schema: String::from(get_proto_complex()),
             references: vec![result_reference],
         };
-        let strategy =
-            SubjectNameStrategy::RecordNameStrategyWithSchema(Box::from(supplied_schema));
+        let strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(supplied_schema);
 
         let encoded_data = encoder
             .encode(

--- a/src/async_impl/schema_registry.rs
+++ b/src/async_impl/schema_registry.rs
@@ -12,9 +12,8 @@ use serde_json::{json, Map, Value};
 
 use crate::error::SRCError;
 use crate::schema_registry_common::{
-    get_schema, get_subject, url_for_call, RawRegisteredSchema, RegisteredReference,
-    RegisteredSchema, SchemaType, SrAuthorization, SrCall, SubjectNameStrategy, SuppliedReference,
-    SuppliedSchema,
+    url_for_call, RawRegisteredSchema, RegisteredReference, RegisteredSchema, SchemaType,
+    SrAuthorization, SrCall, SubjectNameStrategy, SuppliedReference, SuppliedSchema,
 };
 
 /// Settings used to do the calls to schema registry. For simple cases you can use `SrSettings::new`
@@ -219,13 +218,13 @@ pub async fn get_schema_by_subject(
     sr_settings: &SrSettings,
     subject_name_strategy: &SubjectNameStrategy,
 ) -> Result<RegisteredSchema, SRCError> {
-    let subject = get_subject(subject_name_strategy)?;
-    match get_schema(subject_name_strategy) {
+    let subject = subject_name_strategy.get_subject()?;
+    match subject_name_strategy.get_schema() {
         None => {
             let raw_schema = perform_sr_call(sr_settings, SrCall::GetLatest(&subject)).await?;
             raw_to_registered_schema(raw_schema, None).await
         }
-        Some(v) => post_schema(sr_settings, subject, v).await,
+        Some(v) => post_schema(sr_settings, subject, v.clone()).await,
     }
 }
 

--- a/src/avro_common.rs
+++ b/src/avro_common.rs
@@ -160,7 +160,7 @@ pub(crate) fn get_name(schema: &Schema) -> Option<Name> {
     }
 }
 
-pub fn get_supplied_schema(schema: &Schema) -> Box<SuppliedSchema> {
+pub fn get_supplied_schema(schema: &Schema) -> SuppliedSchema {
     let name = match get_name(schema) {
         None => None,
         Some(n) => match n.namespace {
@@ -168,12 +168,12 @@ pub fn get_supplied_schema(schema: &Schema) -> Box<SuppliedSchema> {
             Some(ns) => Some(format!("{}.{}", ns, n.name)),
         },
     };
-    Box::from(SuppliedSchema {
+    SuppliedSchema {
         name,
         schema_type: SchemaType::Avro,
         schema: schema.canonical_form(),
         references: vec![],
-    })
+    }
 }
 
 #[cfg(test)]

--- a/src/avro_common.rs
+++ b/src/avro_common.rs
@@ -38,7 +38,7 @@ fn might_replace(
 ) -> value::Value {
     match val {
         value::Value::Object(v) => replace_in_map(v, child, replace_values),
-        value::Value::Array(v) => replace_in_array(&*v, child, replace_values),
+        value::Value::Array(v) => replace_in_array(&v, child, replace_values),
         value::Value::String(s) if replace_values.contains_key(&*s) => child.clone(),
         p => p,
     }
@@ -98,7 +98,7 @@ pub(crate) fn replace_reference(parent: value::Value, child: value::Value) -> va
     };
     match parent {
         value::Value::Object(v) => replace_in_map(v, &child, &replace_values),
-        value::Value::Array(v) => replace_in_array(&*v, &child, &replace_values),
+        value::Value::Array(v) => replace_in_array(&v, &child, &replace_values),
         p => p,
     }
 }

--- a/src/blocking/avro.rs
+++ b/src/blocking/avro.rs
@@ -323,12 +323,12 @@ impl AvroEncoder {
     /// let sr_settings = SrSettings::new(format!("http://{}", server_address()));
     /// let encoder = AvroEncoder::new(sr_settings);
     ///
-    /// let strategy = SubjectNameStrategy::TopicRecordNameStrategyWithSchema(String::from("hb"), Box::from(SuppliedSchema {
+    /// let strategy = SubjectNameStrategy::TopicRecordNameStrategyWithSchema(String::from("hb"), SuppliedSchema {
     ///                 name: Some(String::from("nl.openweb.data.Heartbeat")),
     ///                 schema_type: SchemaType::Avro,
     ///                 schema: String::from(r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#),
     ///                 references: vec![],
-    ///             }));
+    ///             });
     /// let bytes = encoder.encode(vec![("beat", Value::Long(3))], &strategy);
     /// assert_eq!(bytes, Ok(vec![0, 0, 0, 0, 23, 6]))
     /// ```

--- a/src/blocking/avro.rs
+++ b/src/blocking/avro.rs
@@ -162,7 +162,7 @@ impl AvroDecoder {
                 value: Value::Null,
             }),
             BytesResult::Valid(id, bytes) => self.deserialize(id, &bytes),
-            BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(&*format!(
+            BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(&format!(
                 "Invalid bytes {:?}",
                 bytes
             ))),
@@ -202,7 +202,7 @@ impl AvroDecoder {
                 Ok(v) => Ok(Some(v)),
                 Err(e) => Err(e),
             },
-            BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(&*format!(
+            BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(&format!(
                 "Invalid bytes {:?}",
                 bytes
             ))),
@@ -505,16 +505,16 @@ fn add_references(
             Err(e) => {
                 return Err(SRCError::non_retryable_with_cause(
                     e,
-                    &*format!("problem with reference {:?}", r),
+                    &format!("problem with reference {:?}", r),
                 ));
             }
         };
-        let child: JsonValue = match serde_json::from_str(&*registered_schema.schema) {
+        let child: JsonValue = match serde_json::from_str(&registered_schema.schema) {
             Ok(v) => v,
             Err(e) => {
                 return Err(SRCError::non_retryable_with_cause(
                     e,
-                    &*format!("problem serializing {}", registered_schema.schema),
+                    &format!("problem serializing {}", registered_schema.schema),
                 ));
             }
         };
@@ -534,13 +534,13 @@ fn to_avro_schema(
     match registered_schema.schema_type {
         SchemaType::Avro => (),
         t => {
-            return Err(SRCError::non_retryable_without_cause(&*format!(
+            return Err(SRCError::non_retryable_without_cause(&format!(
                 "type {:?}, is not supported",
                 t
             )));
         }
     }
-    let main_schema = match serde_json::from_str(&*registered_schema.schema) {
+    let main_schema = match serde_json::from_str(&registered_schema.schema) {
         Ok(v) => match add_references(sr_settings, v, registered_schema.references.as_slice()) {
             Ok(u) => u,
             Err(e) => return Err(e),
@@ -560,7 +560,7 @@ fn to_avro_schema(
         })),
         Err(e) => Err(SRCError::non_retryable_with_cause(
             e,
-            &*format!(
+            &format!(
                 "Supplied raw value {:?} cant be turned into a Schema",
                 registered_schema.schema
             ),

--- a/src/blocking/json.rs
+++ b/src/blocking/json.rs
@@ -13,7 +13,7 @@ use crate::blocking::schema_registry::{
 use crate::error::SRCError;
 use crate::json_common::{fetch_fallback, fetch_id, handle_validation, to_bytes, to_value};
 use crate::schema_registry_common::{
-    get_bytes_result, get_subject, BytesResult, RegisteredReference, RegisteredSchema, SchemaType,
+    get_bytes_result, BytesResult, RegisteredReference, RegisteredSchema, SchemaType,
     SubjectNameStrategy,
 };
 
@@ -48,7 +48,7 @@ impl JsonEncoder {
         value: &Value,
         subject_name_strategy: &SubjectNameStrategy,
     ) -> Result<Vec<u8>, SRCError> {
-        let key = get_subject(subject_name_strategy)?;
+        let key = subject_name_strategy.get_subject()?;
         let (validation, id) = self.validate(key, subject_name_strategy, value)?;
         handle_validation(validation, value)?;
         to_bytes(id, value)

--- a/src/blocking/json.rs
+++ b/src/blocking/json.rs
@@ -129,7 +129,7 @@ impl JsonDecoder {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
             BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, &bytes)?)),
-            BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(&*format!(
+            BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(&format!(
                 "Invalid bytes: {:?}",
                 i
             ))),
@@ -182,16 +182,16 @@ fn add_refs_to_scope(
 ) -> Result<(), SRCError> {
     for rr in refs.iter() {
         let rs = get_referenced_schema(sr_settings, rr)?;
-        let id = match Url::from_str(&*rr.name) {
+        let id = match Url::from_str(&rr.name) {
             Ok(v) => v,
-            Err(e) => return Err(SRCError::non_retryable_with_cause(e, &*format!("reference schema with subject {} and version {} has invalid id {}, it has to be a fully qualified url", rr.subject, rr.version, rr.name)))
+            Err(e) => return Err(SRCError::non_retryable_with_cause(e, &format!("reference schema with subject {} and version {} has invalid id {}, it has to be a fully qualified url", rr.subject, rr.version, rr.name)))
         };
         // if it's already part of the scope, it's assumed any references are also already part of the scope.
         if scope.resolve(&id).is_some() {
             return Ok(());
         }
         add_refs_to_scope(scope, sr_settings, &rs.references)?;
-        let def: Value = to_value(&*rs.schema)?;
+        let def: Value = to_value(&rs.schema)?;
         scope.compile_with_id(&id, def, false).unwrap();
     }
     Ok(())
@@ -203,12 +203,12 @@ fn set_scoped_schema(
     registered_schema: &RegisteredSchema,
 ) -> Result<Url, SRCError> {
     add_refs_to_scope(scope, sr_settings, &registered_schema.references)?;
-    let def: Value = match serde_json::from_str(&*registered_schema.schema) {
+    let def: Value = match serde_json::from_str(&registered_schema.schema) {
         Ok(v) => v,
         Err(e) => {
             return Err(SRCError::non_retryable_with_cause(
                 e,
-                &*format!(
+                &format!(
                     "could not parse schema {} with id {} to a value",
                     registered_schema.schema, registered_schema.id
                 ),
@@ -224,7 +224,7 @@ fn set_scoped_schema(
         Err(e) => {
             return Err(SRCError::non_retryable_with_cause(
                 e,
-                &*format!("could not compile schema with id {}", registered_schema.id),
+                &format!("could not compile schema with id {}", registered_schema.id),
             ))
         }
     };
@@ -278,7 +278,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -298,7 +298,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema_with_id(), 10))
+            .with_body(get_json_body(json_result_schema_with_id(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -328,7 +328,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let encoded_data = encoder.encode(&result_example, &strategy);
@@ -349,7 +349,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 7))
+            .with_body(get_json_body(json_result_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -408,7 +408,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 7))
+            .with_body(get_json_body(json_result_schema(), 7))
             .create();
 
         let result = decoder.decode(Some(&*get_payload(7, bytes.clone())));
@@ -437,7 +437,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/10?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -481,7 +481,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/10?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -511,7 +511,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/5?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body_with_reference(
+            .with_body(get_json_body_with_reference(
                 json_test_ref_schema(),
                 5,
                 json_get_result_references(),
@@ -520,7 +520,7 @@ mod tests {
         let _m = mock("GET", "/subjects/result.json/versions/1")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 4))
+            .with_body(get_json_body(json_result_schema(), 4))
             .create();
 
         let result = match decoder.decode(Some(&bytes)) {
@@ -553,7 +553,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/5?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body_with_reference(
+            .with_body(get_json_body_with_reference(
                 json_test_ref_schema(),
                 5,
                 json_get_result_references(),
@@ -562,7 +562,7 @@ mod tests {
         let _m = mock("GET", "/subjects/result.json/versions/1")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(&json_result_schema()[0..30], 4))
+            .with_body(get_json_body(&json_result_schema()[0..30], 4))
             .create();
 
         let error = decoder.decode(Some(&bytes)).unwrap_err();
@@ -597,7 +597,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/5?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body_with_reference(
+            .with_body(get_json_body_with_reference(
                 json_test_ref_schema(),
                 5,
                 json_get_result_references(),
@@ -606,7 +606,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body_with_reference(
+            .with_body(get_json_body_with_reference(
                 json_test_ref_schema(),
                 7,
                 json_get_result_references(),
@@ -615,7 +615,7 @@ mod tests {
         let _m = mock("GET", "/subjects/result.json/versions/1")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 4))
+            .with_body(get_json_body(json_result_schema(), 4))
             .create();
 
         let result = match decoder.decode(Some(&bytes_id_5)) {
@@ -663,7 +663,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_result_schema(), 10))
+            .with_body(get_json_body(json_result_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -686,7 +686,7 @@ mod tests {
         let _m = mock("GET", "/subjects/testresult-value/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_json_body(json_test_ref_schema(), 10))
+            .with_body(get_json_body(json_test_ref_schema(), 10))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));

--- a/src/blocking/proto_decoder.rs
+++ b/src/blocking/proto_decoder.rs
@@ -191,7 +191,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 1))
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -212,7 +212,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 1))
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -239,7 +239,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 1))
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
             .create();
 
         let error = decoder.decode(Some(get_proto_hb_101())).unwrap_err();
@@ -261,7 +261,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/6?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body_with_reference(
+            .with_body(get_proto_body_with_reference(
                 get_proto_complex(),
                 2,
                 get_proto_complex_references(),
@@ -271,7 +271,7 @@ mod tests {
         let _m = mock("GET", "/subjects/result.proto/versions/1")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_result(), 1))
+            .with_body(get_proto_body(get_proto_result(), 1))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));

--- a/src/blocking/proto_raw.rs
+++ b/src/blocking/proto_raw.rs
@@ -74,7 +74,7 @@ impl ProtoRawEncoder {
                 let v = match get_schema_by_subject(&self.sr_settings, subject_name_strategy) {
                     Ok(registered_schema) => Ok(Arc::new(EncodeContext {
                         id: registered_schema.id,
-                        resolver: IndexResolver::new(&*registered_schema.schema),
+                        resolver: IndexResolver::new(&registered_schema.schema),
                     })),
                     Err(e) => Err(e.into_cache()),
                 };
@@ -113,7 +113,7 @@ impl ProtoRawDecoder {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
             BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, &bytes)?)),
-            BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(&*format!(
+            BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(&format!(
                 "Invalid bytes {:?}",
                 i
             ))),
@@ -181,7 +181,7 @@ mod tests {
         let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -205,7 +205,7 @@ mod tests {
         let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -225,7 +225,7 @@ mod tests {
         let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_complex(), 7))
+            .with_body(get_proto_body(get_proto_complex(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -256,7 +256,7 @@ mod tests {
         let _m = mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let error = encoder
@@ -285,7 +285,7 @@ mod tests {
         let _m = mock("POST", "/subjects/result.proto/versions")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_result(), 5))
+            .with_body(get_proto_body(get_proto_result(), 5))
             .create();
 
         let _m = mock("POST", "/subjects/result.proto?deleted=false")
@@ -297,7 +297,7 @@ mod tests {
         let _m = mock("POST", "/subjects/test.proto/versions")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_result(), 6))
+            .with_body(get_proto_body(get_proto_result(), 6))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -344,7 +344,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));
@@ -372,7 +372,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/7?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_hb_schema(), 7))
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
             .create();
 
         let error = decoder.decode(Some(get_proto_hb_101())).unwrap_err();
@@ -391,7 +391,7 @@ mod tests {
         let _m = mock("GET", "/schemas/ids/6?deleted=true")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body_with_reference(
+            .with_body(get_proto_body_with_reference(
                 get_proto_complex(),
                 2,
                 get_proto_complex_references(),
@@ -401,7 +401,7 @@ mod tests {
         let _m = mock("GET", "/subjects/result.proto/versions/1")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(&get_proto_body(get_proto_result(), 1))
+            .with_body(get_proto_body(get_proto_result(), 1))
             .create();
 
         let sr_settings = SrSettings::new(format!("http://{}", server_address()));

--- a/src/blocking/proto_raw.rs
+++ b/src/blocking/proto_raw.rs
@@ -11,7 +11,7 @@ use crate::proto_raw_common::{
 };
 use crate::proto_resolver::{resolve_name, to_index_and_data, IndexResolver};
 use crate::schema_registry_common::{
-    get_bytes_result, get_subject, BytesResult, RegisteredSchema, SchemaType, SubjectNameStrategy,
+    get_bytes_result, BytesResult, RegisteredSchema, SchemaType, SubjectNameStrategy,
 };
 
 /// Encoder that works by prepending the correct bytes in order to make it valid schema registry
@@ -44,7 +44,7 @@ impl ProtoRawEncoder {
         full_name: &str,
         subject_name_strategy: &SubjectNameStrategy,
     ) -> Result<Vec<u8>, SRCError> {
-        let key = get_subject(subject_name_strategy)?;
+        let key = subject_name_strategy.get_subject()?;
         match self.encoding_context(key, subject_name_strategy) {
             Ok(encode_context) => to_bytes(&encode_context, bytes, full_name),
             Err(e) => Err(e),
@@ -56,7 +56,7 @@ impl ProtoRawEncoder {
         bytes: &[u8],
         subject_name_strategy: &SubjectNameStrategy,
     ) -> Result<Vec<u8>, SRCError> {
-        let key = get_subject(subject_name_strategy)?;
+        let key = subject_name_strategy.get_subject()?;
         match self.encoding_context(key, subject_name_strategy) {
             Ok(encode_context) => to_bytes_single_message(&encode_context, bytes),
             Err(e) => Err(e),
@@ -314,8 +314,7 @@ mod tests {
             schema: String::from(get_proto_complex()),
             references: vec![result_reference],
         };
-        let strategy =
-            SubjectNameStrategy::RecordNameStrategyWithSchema(Box::from(supplied_schema));
+        let strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(supplied_schema);
 
         let encoded_data = encoder
             .encode(

--- a/src/blocking/schema_registry.rs
+++ b/src/blocking/schema_registry.rs
@@ -11,9 +11,8 @@ use serde_json::{json, Map, Value};
 
 use crate::error::SRCError;
 use crate::schema_registry_common::{
-    get_schema, get_subject, url_for_call, RawRegisteredSchema, RegisteredReference,
-    RegisteredSchema, SchemaType, SrAuthorization, SrCall, SubjectNameStrategy, SuppliedReference,
-    SuppliedSchema,
+    url_for_call, RawRegisteredSchema, RegisteredReference, RegisteredSchema, SchemaType,
+    SrAuthorization, SrCall, SubjectNameStrategy, SuppliedReference, SuppliedSchema,
 };
 
 /// Settings used to do the calls to schema registry. For simple cases you can use `SrSettings::new`
@@ -215,13 +214,13 @@ pub fn get_schema_by_subject(
     sr_settings: &SrSettings,
     subject_name_strategy: &SubjectNameStrategy,
 ) -> Result<RegisteredSchema, SRCError> {
-    let subject = get_subject(subject_name_strategy)?;
-    match get_schema(subject_name_strategy) {
+    let subject = subject_name_strategy.get_subject()?;
+    match subject_name_strategy.get_schema() {
         None => {
             let raw_schema = perform_sr_call(sr_settings, SrCall::GetLatest(&subject))?;
             raw_to_registered_schema(raw_schema, None)
         }
-        Some(v) => post_schema(sr_settings, subject, v),
+        Some(v) => post_schema(sr_settings, subject, v.clone()),
     }
 }
 
@@ -231,10 +230,7 @@ pub fn get_referenced_schema(
 ) -> Result<RegisteredSchema, SRCError> {
     let raw_schema = perform_sr_call(
         sr_settings,
-        SrCall::GetBySubjectAndVersion(
-            &registered_reference.subject,
-            registered_reference.version,
-        ),
+        SrCall::GetBySubjectAndVersion(&registered_reference.subject, registered_reference.version),
     )?;
     raw_to_registered_schema(raw_schema, None)
 }

--- a/src/json_common.rs
+++ b/src/json_common.rs
@@ -12,12 +12,12 @@ pub(crate) fn handle_validation(
     if validation.is_strictly_valid() {
         Ok(())
     } else if validation.errors.is_empty() {
-        Err(SRCError::non_retryable_without_cause(&*format!(
+        Err(SRCError::non_retryable_without_cause(&format!(
             "Value {} was not valid because of missing references",
             value
         )))
     } else {
-        Err(SRCError::non_retryable_without_cause(&*format!(
+        Err(SRCError::non_retryable_without_cause(&format!(
             "Value {} was not valid according to the schema because {:?}",
             value, validation.errors
         )))
@@ -52,8 +52,8 @@ pub(crate) fn fetch_id(def: &Value) -> Option<Url> {
 }
 
 pub(crate) fn fetch_fallback(url: &str, id: u32) -> Url {
-    let id = &*format!("{}/id/{}.json", url, id);
-    Url::parse(id).unwrap()
+    let id = format!("{}/id/{}.json", url, id);
+    Url::parse(&id).unwrap()
 }
 
 pub(crate) fn to_value(str: &str) -> Result<Value, SRCError> {
@@ -62,7 +62,7 @@ pub(crate) fn to_value(str: &str) -> Result<Value, SRCError> {
         Err(e) => {
             return Err(SRCError::non_retryable_with_cause(
                 e,
-                &*format!("could not parse schema {} to a value", str),
+                &format!("could not parse schema {} to a value", str),
             ))
         }
     };

--- a/src/proto_raw_common.rs
+++ b/src/proto_raw_common.rs
@@ -18,7 +18,7 @@ pub(crate) fn to_bytes(
             result
         }
         None => {
-            return Err(SRCError::non_retryable_without_cause(&*format!(
+            return Err(SRCError::non_retryable_without_cause(&format!(
                 "could not find name {} with resolver",
                 full_name
             )))
@@ -49,7 +49,7 @@ pub(crate) fn to_decode_context(registered_schema: RegisteredSchema) -> DecodeCo
     let schema = String::from(&registered_schema.schema);
     DecodeContext {
         schema: registered_schema,
-        resolver: MessageResolver::new(&*schema),
+        resolver: MessageResolver::new(&schema),
     }
 }
 

--- a/src/proto_resolver.rs
+++ b/src/proto_resolver.rs
@@ -22,7 +22,7 @@ impl MessageResolver {
         let helper = ResolverHelper::new(s);
         let map = DashMap::new();
         for i in &helper.indexes {
-            map.insert(i.clone(), Arc::new(find_name(&*i, &helper)));
+            map.insert(i.clone(), Arc::new(find_name(i, &helper)));
         }
         MessageResolver {
             map,
@@ -43,7 +43,7 @@ impl IndexResolver {
         let helper = ResolverHelper::new(s);
         let map = DashMap::new();
         for i in &helper.indexes {
-            map.insert(find_name(&*i, &helper), Arc::new(i.clone()));
+            map.insert(find_name(i, &helper), Arc::new(i.clone()));
         }
         IndexResolver { map }
     }
@@ -100,7 +100,7 @@ impl ResolverHelper {
         let mut lex = Token::lexer(s);
         let mut next: Option<Token> = lex.next();
 
-        while next != None {
+        while next.is_some() {
             match next.unwrap() {
                 Token::Package => {
                     let slice = lex.slice();
@@ -110,7 +110,7 @@ impl ResolverHelper {
                     let slice = lex.slice();
                     let message = String::from(slice[8..slice.len()].trim());
                     for i in &indexes {
-                        if same_vec(i, &*index) {
+                        if same_vec(i, &index) {
                             *index.last_mut().unwrap() += 1;
                         }
                     }
@@ -198,7 +198,7 @@ pub(crate) fn resolve_name(
 ) -> Result<Arc<String>, SRCError> {
     match resolver.find_name(index) {
         Some(n) => Ok(n),
-        None => Err(SRCError::non_retryable_without_cause(&*format!(
+        None => Err(SRCError::non_retryable_without_cause(&format!(
             "Could not retrieve name for index: {:?}",
             index
         ))),

--- a/tests/blocking/avro_tests.rs
+++ b/tests/blocking/avro_tests.rs
@@ -92,7 +92,7 @@ fn test1_topic_name_strategy_with_schema() {
         false,
         get_heartbeat_schema(),
     );
-    do_avro_test(topic, key_strategy, value_strategy)
+    do_avro_test(topic, key_strategy, &value_strategy)
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn test2_record_name_strategy_with_schema() {
     let topic = "recordnamestrategy";
     let key_strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(get_heartbeat_schema());
     let value_strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(get_heartbeat_schema());
-    do_avro_test(topic, key_strategy, value_strategy)
+    do_avro_test(topic, key_strategy, &value_strategy)
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn test3_topic_record_name_strategy_with_schema() {
         String::from(topic),
         get_heartbeat_schema(),
     );
-    do_avro_test(topic, key_strategy, value_strategy)
+    do_avro_test(topic, key_strategy, &value_strategy)
 }
 
 #[test]
@@ -122,7 +122,7 @@ fn test4_topic_name_strategy_schema_now_available() {
     let topic = "topicnamestrategy";
     let key_strategy = SubjectNameStrategy::TopicNameStrategy(String::from(topic), true);
     let value_strategy = SubjectNameStrategy::TopicNameStrategy(String::from(topic), false);
-    do_avro_test(topic, key_strategy, value_strategy)
+    do_avro_test(topic, key_strategy, &value_strategy)
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn test5_record_name_strategy_schema_now_available() {
         SubjectNameStrategy::RecordNameStrategy(String::from("nl.openweb.data.Heartbeat"));
     let value_strategy =
         SubjectNameStrategy::RecordNameStrategy(String::from("nl.openweb.data.Heartbeat"));
-    do_avro_test(topic, key_strategy, value_strategy)
+    do_avro_test(topic, key_strategy, &value_strategy)
 }
 
 #[test]
@@ -146,7 +146,7 @@ fn test6_topic_record_name_strategy_schema_now_available() {
         String::from(topic),
         String::from("nl.openweb.data.Heartbeat"),
     );
-    do_avro_test(topic, key_strategy, value_strategy)
+    do_avro_test(topic, key_strategy, &value_strategy)
 }
 
 #[test]

--- a/tests/blocking/avro_tests.rs
+++ b/tests/blocking/avro_tests.rs
@@ -16,15 +16,15 @@ fn get_brokers() -> &'static str {
     "127.0.0.1:9092"
 }
 
-fn get_heartbeat_schema() -> Box<SuppliedSchema> {
-    Box::from(SuppliedSchema {
+fn get_heartbeat_schema() -> SuppliedSchema {
+    SuppliedSchema {
         name: Some(String::from("nl.openweb.data.Heartbeat")),
         schema_type: SchemaType::Avro,
         schema: String::from(
             r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#,
         ),
         references: vec![],
-    })
+    }
 }
 
 fn test_beat_value(key_value: i64, value_value: i64) -> Box<dyn Fn(DeserializedAvroRecord)> {
@@ -92,7 +92,7 @@ fn test1_topic_name_strategy_with_schema() {
         false,
         get_heartbeat_schema(),
     );
-    do_avro_test(topic, key_strategy, &value_strategy)
+    do_avro_test(topic, key_strategy, value_strategy)
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn test2_record_name_strategy_with_schema() {
     let topic = "recordnamestrategy";
     let key_strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(get_heartbeat_schema());
     let value_strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(get_heartbeat_schema());
-    do_avro_test(topic, key_strategy, &value_strategy)
+    do_avro_test(topic, key_strategy, value_strategy)
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn test3_topic_record_name_strategy_with_schema() {
         String::from(topic),
         get_heartbeat_schema(),
     );
-    do_avro_test(topic, key_strategy, &value_strategy)
+    do_avro_test(topic, key_strategy, value_strategy)
 }
 
 #[test]
@@ -122,7 +122,7 @@ fn test4_topic_name_strategy_schema_now_available() {
     let topic = "topicnamestrategy";
     let key_strategy = SubjectNameStrategy::TopicNameStrategy(String::from(topic), true);
     let value_strategy = SubjectNameStrategy::TopicNameStrategy(String::from(topic), false);
-    do_avro_test(topic, key_strategy, &value_strategy)
+    do_avro_test(topic, key_strategy, value_strategy)
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn test5_record_name_strategy_schema_now_available() {
         SubjectNameStrategy::RecordNameStrategy(String::from("nl.openweb.data.Heartbeat"));
     let value_strategy =
         SubjectNameStrategy::RecordNameStrategy(String::from("nl.openweb.data.Heartbeat"));
-    do_avro_test(topic, key_strategy, &value_strategy)
+    do_avro_test(topic, key_strategy, value_strategy)
 }
 
 #[test]
@@ -146,7 +146,7 @@ fn test6_topic_record_name_strategy_schema_now_available() {
         String::from(topic),
         String::from("nl.openweb.data.Heartbeat"),
     );
-    do_avro_test(topic, key_strategy, &value_strategy)
+    do_avro_test(topic, key_strategy, value_strategy)
 }
 
 #[test]


### PR DESCRIPTION
This contains 4 improvements:

1) implement the code improvements suggested by `cargo clippy`
2) clean up the SubjectNameStrategy enum to:
  a) be more along the lines of idiomatic rust code
  b) remove unnecessary boxes
3) expose the `get_schema_and_id` function for the encoder
4) fix the function signature for `EasyAvroEncoder::encode` to allow non static strings as keys