### PR TITLE
Handle slash in subject name while performing Schema Registry API calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,8 @@ version = "^0.14"
 optional = true
 
 [dependencies.protofish]
-git = "https://github.com/Rantanen/protofish.git"
-rev = "bd53a38"
+git = "https://github.com/fennel-ai/protofish.git"
+branch = "main"
 optional = true
 
 [dependencies.url]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,8 @@ version = "^0.14"
 optional = true
 
 [dependencies.protofish]
-version = "^0.5"
+git = "https://github.com/Rantanen/protofish.git"
+rev = "bd53a38"
 optional = true
 
 [dependencies.url]

--- a/src/schema_registry_common.rs
+++ b/src/schema_registry_common.rs
@@ -169,13 +169,21 @@ pub enum SrCall<'a> {
 pub(crate) fn url_for_call(call: &SrCall, base_url: &str) -> String {
     match call {
         SrCall::GetById(id) => format!("{}/schemas/ids/{}?deleted=true", base_url, id),
-        SrCall::GetLatest(subject) => format!("{}/subjects/{}/versions/latest", base_url, subject),
-        SrCall::GetBySubjectAndVersion(subject, version) => {
-            format!("{}/subjects/{}/versions/{}", base_url, subject, version)
+        SrCall::GetLatest(subject) => {
+            // Use escape sequences instead of slashes in the subject
+            format!("{}/subjects/{}/versions/latest", base_url, subject.replace("/", "%2F"))
         }
-        SrCall::PostNew(subject, _) => format!("{}/subjects/{}/versions", base_url, subject),
+        SrCall::GetBySubjectAndVersion(subject, version) => {
+            // Use escape sequences instead of slashes in the subject
+            format!("{}/subjects/{}/versions/{}", base_url, subject.replace("/", "%2F"), version)
+        }
+        SrCall::PostNew(subject, _) => {
+            // Use escape sequences instead of slashes in the subject
+            format!("{}/subjects/{}/versions", base_url, subject.replace("/", "%2F"))
+        }
         SrCall::PostForVersion(subject, _) => {
-            format!("{}/subjects/{}?deleted=false", base_url, subject)
+            // Use escape sequences instead of slashes in the subject
+            format!("{}/subjects/{}?deleted=false", base_url, subject.replace("/", "%2F"))
         }
     }
 }


### PR DESCRIPTION
Description
==========
- One of the limitations mentioned in schema registry [documentation](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#limitations) is that subject name can contain "/" character. However, we have to escape it in the schema registry APIs 
- This change replaces "/" in the subject name with "%2F" thereby allowing API calls to succeed

Use case
==========
- We have one of our schemas referencing other schema containing "/" in its name. Due to the above mentioned limitation, `schema_registry_converter::async_impl::proto_decoder::deserialize_with_context` method is returning `Could not get id from response` as the response. After this fix, deserialize_with_context is returning valid data and things are working E2E as expected 

Testing
==========
- Tested on my confluent schema registry with subject name as "a/b/c.proto" 
API call failing with ```{"error_code":404,"message":"HTTP 404 Not Found"}``` error before the change and the call has
succeeded after changing subject name to "a%2Fb%2Fc.proto"