### PR TITLE
Resolve common dependencies from dependent schemas

### DIFF
--- a/src/async_impl/proto_decoder.rs
+++ b/src/async_impl/proto_decoder.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use bytes::Bytes;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
@@ -181,10 +182,10 @@ pub struct DecodeContext {
 
 fn into_decode_context(vec_of_schemas: Vec<String>) -> Result<DecodeContext, SRCError> {
     let resolver = MessageResolver::new(vec_of_schemas.last().unwrap());
-    let mut files: Vec<String> = Vec::new();
+    let mut files: HashSet<String> = HashSet::new();
     add_common_files(resolver.imports(), &mut files);
     for s in vec_of_schemas {
-        files.push(s);
+        files.insert(s);
     }
     match Context::parse(files) {
         Ok(context) => Ok(DecodeContext { resolver, context }),

--- a/src/blocking/proto_decoder.rs
+++ b/src/blocking/proto_decoder.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use bytes::Bytes;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
@@ -135,13 +136,13 @@ pub struct DecodeResultWithContext {
 fn add_files(
     sr_settings: &SrSettings,
     registered_schema: RegisteredSchema,
-    files: &mut Vec<String>,
+    files: &mut HashSet<String>,
 ) -> Result<(), SRCError> {
     for r in registered_schema.references {
         let child_schema = get_referenced_schema(sr_settings, &r)?;
         add_files(sr_settings, child_schema, files)?;
     }
-    files.push(registered_schema.schema);
+    files.insert(registered_schema.schema);
     Ok(())
 }
 
@@ -157,7 +158,7 @@ fn to_resolve_context(
     registered_schema: RegisteredSchema,
 ) -> Result<Arc<DecodeContext>, SRCError> {
     let resolver = MessageResolver::new(&registered_schema.schema);
-    let mut files = Vec::new();
+    let mut files = HashSet::new();
     add_common_files(resolver.imports(), &mut files);
     add_files(sr_settings, registered_schema.clone(), &mut files)?;
     match Context::parse(&files) {

--- a/src/proto_common_types.rs
+++ b/src/proto_common_types.rs
@@ -1,13 +1,15 @@
+use std::collections::HashSet;
+
 /// Adds the schema of the common type imports
-pub(crate) fn add_common_files(imports: &Vec<String>, files: &mut Vec<String>) {
+pub(crate) fn add_common_files(imports: &Vec<String>, files: &mut HashSet<String>) {
     for import in imports {
         if let Some(common_schema) = is_common_import(import) {
-            files.push(String::from(get_schema(&common_schema)));
+            files.insert(String::from(get_schema(&common_schema)));
             continue;
         }
         if let Some(common_type) = is_common_type_import(import) {
             for common_schema in get_schemas(common_type) {
-                files.push(String::from(get_schema(common_schema)))
+                files.insert(String::from(get_schema(common_schema)));
             }
         }
     }
@@ -3597,6 +3599,7 @@ message BytesValue {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use crate::proto_common_types::{
         add_common_files, get_schema, get_schemas, CommonSchema, CommonType,
     };
@@ -3665,7 +3668,7 @@ mod tests {
             String::from("google/protobuf/wrappers.proto"),
         ];
 
-        let mut files: Vec<String> = vec![];
+        let mut files: HashSet<String> = HashSet::new();
 
         add_common_files(&test_imports, &mut files);
 


### PR DESCRIPTION
This PR fixes the below issues:
- If A.proto has 2 imports B and C, both B and C internally import D, it is causing duplicate import error. We now store the files in hashset thereby eliminating duplicates
- If A.proto imports B.proto and B.proto imports common dependencies like google.protobuf.timestamp, we observe Unknown type "google.protobuf.timestamp" error. This is happening because `into_decode_context` method doesn't resolve common dependencies for all elements in vector of schemas. Resolving the common dependencies for all of them fixes this issue 