### PR TITLE
Updates module and implementation documentation

### DIFF
--- a/src/async_impl/easy_avro.rs
+++ b/src/async_impl/easy_avro.rs
@@ -1,3 +1,10 @@
+//! [`Arc`] wrapped implementations for [`AvroEncoder`] and [`AvroDecoder`].
+//!
+//! Implementations for [`EasyAvroDecoder`] and [`EasyAvroEncoder`]. These Newtype
+//! structs wrap the existing [`AvroDecoder`] and [`AvroEncoder`] structs in an [`Arc`] to
+//! make it _easy_.
+//!
+//! **NOTE**: This module requires `easy` and `avro` features to be enabled.
 use crate::async_impl::schema_registry::SrSettings;
 use crate::avro_common::{DecodeResult, DecodeResultWithSchema};
 use crate::error::SRCError;
@@ -10,7 +17,8 @@ use apache_avro::types::Value;
 use serde::Serialize;
 use std::sync::Arc;
 
-/// A decoder used to transform bytes to a [DecodeResult], its much like [AvroDecoder] but wrapped with an arc to make it easier.
+/// A decoder used to transform bytes to a [DecodeResult], its much like
+/// [AvroDecoder] but wrapped with an [`Arc`] to make it easier.
 pub struct EasyAvroDecoder {
     decoder: Arc<AvroDecoder<'static>>,
 }
@@ -31,7 +39,8 @@ impl EasyAvroDecoder {
     }
 }
 
-/// An encoder used to transform a [Value] to bytes, its much like [AvroEncoder] but wrapped with an arc to make it easier.
+/// An encoder used to transform a [Value] to bytes, its much like [AvroEncoder]
+/// but wrapped with an [`Arc`] to make it easier.
 pub struct EasyAvroEncoder {
     encoder: Arc<AvroEncoder<'static>>,
 }

--- a/src/async_impl/easy_json.rs
+++ b/src/async_impl/easy_json.rs
@@ -1,3 +1,10 @@
+//! [`Arc`] wrapped implementations for [`JsonEncoder`] and [`JsonDecoder`]
+//!
+//! Implementations for [`EasyJsonDecoder`] and [`EasyJsonEncoder`]. These Newtype
+//! structs wrap the [`JsonDecoder`] and [`JsonEncoder`] structs in an [`Arc`] to make it
+//! _easy_.
+//!
+//! **NOTE**: This module requires `easy` and `json` features to be enabled.
 use crate::async_impl::json::{DecodeResult, JsonDecoder, JsonEncoder};
 use crate::async_impl::schema_registry::SrSettings;
 use crate::error::SRCError;

--- a/src/async_impl/json.rs
+++ b/src/async_impl/json.rs
@@ -1,3 +1,6 @@
+//! Implementations for JSON based Schemas.
+//!
+//! **NOTE**: Requires the `json` feature
 use std::str::FromStr;
 use std::sync::Arc;
 

--- a/src/async_impl/mod.rs
+++ b/src/async_impl/mod.rs
@@ -1,3 +1,4 @@
+//! async supported implementations. Requires `futures` feature.
 #[cfg(feature = "avro")]
 pub mod avro;
 #[cfg(all(feature = "easy", feature = "avro"))]

--- a/src/avro_common.rs
+++ b/src/avro_common.rs
@@ -1,3 +1,4 @@
+//! Common structures and functions of the crate
 use apache_avro::schema::{Name, Schema};
 use apache_avro::types::{Record, Value};
 use apache_avro::{to_avro_datum, to_value};

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -1,3 +1,4 @@
+//! blocking implementations. Requires `blocking` feature.
 #[cfg(feature = "avro")]
 pub mod avro;
 #[cfg(feature = "json")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+//! implementation for [`SRCError`]
 use std::error::Error;
 use std::fmt;
 use std::fmt::Display;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,9 @@
 //!
 //! For Encoding data it's possible to supply a schema else the latest available schema will be used.
 //! For Decoding it works the same as the Java part, using the id encoded in the bytes, the
-//! correct schema will be fetched and used to decode the message to a apache_avro::types::Value.
+//! correct schema will be fetched and used to decode the message to a [`apache_avro::types::Value`].
 //!
-//! Resulting errors are SRCError, besides the error they also contain a .cached which tells whether
+//! Resulting errors are [`crate::error::SRCError`], besides the error they also contain a .cached which tells whether
 //! the error is cached or not. Another property added to the error is retriable, in some cases, like
 //! when the network fails it might be worth to retry the same function. The library itself doesn't
 //! automatically does retries.


### PR DESCRIPTION
This PR makes it a bit easier for unfamiliar users to become acquainted with the contents of the crate from higher levels of the crate documentation.

- Succinct module level description which may include links to the primary implementations.

- Adds section to module level docstrings describing which features need to be enabled to use the implementations of that module.

Make sure there is an related issues, and the docs and unit tests are also updated.

Thanks for this crate, it's very helpful. When I was going through the docs on https://docs.rs I had to cross reference the source code to determine the purpose of a module and what features were required to use that module. This pull-request adds the documentation to the top of the modules to make it a bit easier for users to quickly identify relevant modules and what features need to be enabled to use them.