### PR TITLE
Support adding properties and tags metadata

### DIFF
--- a/src/async_impl/avro.rs
+++ b/src/async_impl/avro.rs
@@ -364,6 +364,8 @@ impl<'a> AvroEncoder<'a> {
     ///                 schema_type: SchemaType::Avro,
     ///                 schema: String::from(r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#),
     ///                 references: vec![],
+    ///                 properties: None,
+    ///                 tags: None,
     ///             });
     /// let bytes = encoder.encode(vec![("beat", Value::Long(3))], strategy).await;
     /// assert_eq!(bytes, Ok(vec![0, 0, 0, 0, 23, 6]));
@@ -1262,6 +1264,8 @@ mod tests {
                 r#"{"type":"record","name":"Balance","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#,
             ),
             references: vec![],
+            properties: None,
+            tags: None,
         });
         let err = encoder
             .encode(vec![("beat", Value::Long(3))], strategy)
@@ -1355,6 +1359,8 @@ mod tests {
                     r#"{"type":"record","name":"Name","namespace":"nl.openweb.data","fields":[{"name":"name","type":"string","avro.java.string":"String"}]}"#,
                 ),
                 references: vec![],
+                properties: None,
+                tags: None,
             },
         );
         let bytes = encoder
@@ -1378,6 +1384,8 @@ mod tests {
                     r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#,
                 ),
                 references: vec![],
+                properties: None,
+                tags: None,
             },
         );
         let bytes = encoder
@@ -1410,6 +1418,8 @@ mod tests {
                 r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#,
             ),
             references: vec![],
+            properties: None,
+            tags: None,
         });
         let bytes = encoder
             .encode(vec![("beat", Value::Long(3))], strategy)
@@ -1441,6 +1451,8 @@ mod tests {
                 r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#,
             ),
             references: vec![],
+            properties: None,
+            tags: None,
         });
         let result = encoder
             .encode(vec![("beat", Value::Long(3))], strategy)
@@ -1478,6 +1490,8 @@ mod tests {
                     r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#,
                 ),
                 references: vec![],
+                properties: None,
+                tags: None,
             },
         );
         let bytes = encoder
@@ -1505,6 +1519,8 @@ mod tests {
                     r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#,
                 ),
                 references: vec![],
+                properties: None,
+                tags: None,
             },
         );
         let error = encoder
@@ -1531,6 +1547,8 @@ mod tests {
             schema_type: SchemaType::Avro,
             schema: String::from(r#"{"type":"record","name":"Name"}"#),
             references: vec![],
+            properties: None,
+            tags: None,
         };
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
         let result = to_avro_schema(&sr_settings, registered_schema)
@@ -1551,6 +1569,8 @@ mod tests {
                 r#"syntax = "proto3"; package org.schema_registry_test_app.proto; message Result { string up = 1; string down = 2; }"#,
             ),
             references: vec![],
+            properties: None,
+            tags: None,
         };
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
         let err = to_avro_schema(&sr_settings, registered_schema)

--- a/src/async_impl/proto_raw.rs
+++ b/src/async_impl/proto_raw.rs
@@ -398,12 +398,16 @@ mod tests {
             subject: String::from("result.proto"),
             schema: String::from(get_proto_result()),
             references: vec![],
+            properties: None,
+            tags: None,
         };
         let supplied_schema = SuppliedSchema {
             name: Some(String::from("test.proto")),
             schema_type: SchemaType::Protobuf,
             schema: String::from(get_proto_complex()),
             references: vec![result_reference],
+            properties: None,
+            tags: None,
         };
         let strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(supplied_schema);
 

--- a/src/avro_common.rs
+++ b/src/avro_common.rs
@@ -1,4 +1,5 @@
 //! Common structures and functions of the crate
+
 use apache_avro::schema::{Name, Schema};
 use apache_avro::types::{Record, Value};
 use apache_avro::{to_avro_datum, to_value};
@@ -178,6 +179,8 @@ pub fn get_supplied_schema(schema: &Schema) -> SuppliedSchema {
         schema_type: SchemaType::Avro,
         schema: schema.canonical_form(),
         references: vec![],
+        properties: None,
+        tags: None,
     }
 }
 

--- a/src/blocking/proto_raw.rs
+++ b/src/blocking/proto_raw.rs
@@ -162,7 +162,6 @@ pub struct RawDecodeResult {
 
 #[cfg(test)]
 mod tests {
-
     use crate::blocking::proto_raw::{ProtoRawDecoder, ProtoRawEncoder};
     use crate::blocking::schema_registry::SrSettings;
     use crate::schema_registry_common::{
@@ -334,12 +333,16 @@ mod tests {
             subject: String::from("result.proto"),
             schema: String::from(get_proto_result()),
             references: vec![],
+            properties: None,
+            tags: None,
         };
         let supplied_schema = SuppliedSchema {
             name: Some(String::from("test.proto")),
             schema_type: SchemaType::Protobuf,
             schema: String::from(get_proto_complex()),
             references: vec![result_reference],
+            properties: None,
+            tags: None,
         };
         let strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(supplied_schema);
 

--- a/src/blocking/schema_registry.rs
+++ b/src/blocking/schema_registry.rs
@@ -282,6 +282,8 @@ fn raw_to_registered_schema(
         schema_type,
         schema,
         references,
+        properties: raw_schema.properties,
+        tags: raw_schema.tags,
     })
 }
 
@@ -321,6 +323,8 @@ pub fn post_schema(
         schema_type: schema.schema_type,
         schema: schema.schema,
         references,
+        properties: schema.properties,
+        tags: schema.tags,
     })
 }
 
@@ -390,6 +394,8 @@ fn post_reference(
         name: reference.name,
         subject: reference.subject,
         version,
+        properties: reference.properties,
+        tags: reference.tags,
     })
 }
 

--- a/src/schema_registry_common.rs
+++ b/src/schema_registry_common.rs
@@ -1,7 +1,7 @@
 //! Contains structs, enums' and functions common to async and blocking implementation of schema
 //! registry. So stuff dealing with the responses from schema registry, determining the subject, etc.
 use core::fmt;
-
+use std::collections::HashMap;
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
 use serde::{Deserialize, Serialize};
 
@@ -41,6 +41,8 @@ pub struct SuppliedReference {
     pub subject: String,
     pub schema: String,
     pub references: Vec<SuppliedReference>,
+    pub properties: Option<HashMap<String, String>>,
+    pub tags: Option<HashMap<String, Vec<String>>>,
 }
 
 /// Schema as it might be provided to create messages, they will be added to th schema registry if
@@ -51,6 +53,8 @@ pub struct SuppliedSchema {
     pub schema_type: SchemaType,
     pub schema: String,
     pub references: Vec<SuppliedReference>,
+    pub properties: Option<HashMap<String, String>>,
+    pub tags: Option<HashMap<String, Vec<String>>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -58,6 +62,8 @@ pub struct RegisteredReference {
     pub name: String,
     pub subject: String,
     pub version: u32,
+    pub properties: Option<HashMap<String, String>>,
+    pub tags: Option<HashMap<String, Vec<String>>>,
 }
 
 /// Schema as retrieved from the schema registry. It's close to the json received and doesn't do
@@ -68,6 +74,8 @@ pub struct RegisteredSchema {
     pub schema_type: SchemaType,
     pub schema: String,
     pub references: Vec<RegisteredReference>,
+    pub properties: Option<HashMap<String, String>>,
+    pub tags: Option<HashMap<String, Vec<String>>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -79,6 +87,8 @@ pub struct RawRegisteredSchema {
     pub schema_type: Option<String>,
     pub references: Option<Vec<RegisteredReference>>,
     pub schema: Option<String>,
+    pub properties: Option<HashMap<String, String>>,
+    pub tags: Option<HashMap<String, Vec<String>>>,
 }
 
 /// Intermediate result to just handle the byte transformation. When used in a decoder just the
@@ -296,13 +306,17 @@ mod test {
             schema_type: SchemaType::Avro,
             schema: String::from("some schema"),
             references: vec![],
+            properties: None,
+            tags: None,
         };
         assert_eq!(0, registered_schema.id);
         assert_eq!(SchemaType::Avro, registered_schema.schema_type);
         assert_eq!("some schema", registered_schema.schema);
         assert!(registered_schema.references.is_empty());
+        assert!(registered_schema.properties.is_none());
+        assert!(registered_schema.tags.is_none());
         assert_eq!(
-            r#"RegisteredSchema { id: 0, schema_type: Avro, schema: "some schema", references: [] }"#,
+            r#"RegisteredSchema { id: 0, schema_type: Avro, schema: "some schema", references: [], properties: None, tags: None }"#,
             format!("{:?}", registered_schema)
         )
     }
@@ -328,6 +342,8 @@ mod test {
                 schema_type: SchemaType::Other(String::from("foo")),
                 schema: "".to_string(),
                 references: vec![],
+                properties: None,
+                tags: None,
             },
         );
 

--- a/tests/blocking/avro_tests.rs
+++ b/tests/blocking/avro_tests.rs
@@ -24,6 +24,8 @@ fn get_heartbeat_schema() -> SuppliedSchema {
             r#"{"type":"record","name":"Heartbeat","namespace":"nl.openweb.data","fields":[{"name":"beat","type":"long"}]}"#,
         ),
         references: vec![],
+        properties: None,
+        tags: None,
     }
 }
 


### PR DESCRIPTION
Confluent's data contract from the schema registration allows to annotate the schema with custom metadata, namely properties and tags; see https://docs.confluent.io/platform/current/schema-registry/fundamentals/data-contracts.htm

