### PR TITLE
Fix Raw Schema Registry Response Parsing for Metadata (tags and properties)

### DIFF
--- a/src/schema_registry_common.rs
+++ b/src/schema_registry_common.rs
@@ -68,7 +68,7 @@ pub struct RegisteredReference {
 
 /// Schema as retrieved from the schema registry. It's close to the json received and doesn't do
 /// type specific transformations.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RegisteredSchema {
     pub id: u32,
     pub schema_type: SchemaType,
@@ -78,7 +78,7 @@ pub struct RegisteredSchema {
     pub tags: Option<HashMap<String, Vec<String>>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RawRegisteredSchema {
     pub subject: Option<String>,
@@ -87,8 +87,14 @@ pub struct RawRegisteredSchema {
     pub schema_type: Option<String>,
     pub references: Option<Vec<RegisteredReference>>,
     pub schema: Option<String>,
-    pub properties: Option<HashMap<String, String>>,
+    pub metadata: Option<Metadata>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Metadata {
     pub tags: Option<HashMap<String, Vec<String>>>,
+    pub properties: Option<HashMap<String, String>>,
 }
 
 /// Intermediate result to just handle the byte transformation. When used in a decoder just the


### PR DESCRIPTION
This PR updates the schema registry response parsing logic to correctly handle the `metadata` field, which contains `tags` and `properties`.  
- Refactors `RawRegisteredSchema` to nest `tags` and `properties` under the `metadata` key.
- Updates conversion logic to extract tags from the new structure.
- Adds/updates tests to verify parsing and conversion to `RegisteredSchema` against realistic JSON samples.

Example schema-reg json response we need to parse:

```json
{
  "subject": "ietf-tls-common",
  "version": 1,
  "id": 68,
  "guid": "9550709c-d6c9-0194-fefa-6381b953668d",
  "schemaType": "YANG",
  "references": [
    {
      "name": "iana-tls-cipher-suite-algs",
      "subject": "iana-tls-cipher-suite-algs",
      "version": 1
    },
    {
      "name": "ietf-crypto-types",
      "subject": "ietf-crypto-types",
      "version": 1
    },
    {
      "name": "ietf-keystore",
      "subject": "ietf-keystore",
      "version": 1
    }
  ],
  "metadata": {
    "tags": {
      "features": [
        "algorithm-discovery",
        "asymmetric-key-pair-generation",
        "hello-params",
        "tls12",
        "tls13"
      ]
    }
  },
  "schema": "module ietf-tls-common { ... }\n",
  "ts": 1763117237172,
  "deleted": false
}
```
