### PR TITLE
feat: Add clone/debug to all easy encoders/decoders

### DIFF
--- a/src/async_impl/easy_avro.rs
+++ b/src/async_impl/easy_avro.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 /// A decoder used to transform bytes to a [DecodeResult], its much like
 /// [AvroDecoder] but wrapped with an [`Arc`] to make it easier.
+#[derive(Clone, Debug)]
 pub struct EasyAvroDecoder {
     decoder: Arc<AvroDecoder<'static>>,
 }
@@ -41,6 +42,7 @@ impl EasyAvroDecoder {
 
 /// An encoder used to transform a [Value] to bytes, its much like [AvroEncoder]
 /// but wrapped with an [`Arc`] to make it easier.
+#[derive(Clone, Debug)]
 pub struct EasyAvroEncoder {
     encoder: Arc<AvroEncoder<'static>>,
 }

--- a/src/async_impl/easy_json.rs
+++ b/src/async_impl/easy_json.rs
@@ -13,6 +13,7 @@ use serde_json::Value;
 use std::sync::Arc;
 
 /// A decoder used to transform bytes to a [DecodeResult], its much like [JsonDecoder] but wrapped with an arc to make it easier.
+#[derive(Clone, Debug)]
 pub struct EasyJsonDecoder {
     decoder: Arc<JsonDecoder<'static>>,
 }
@@ -28,6 +29,7 @@ impl EasyJsonDecoder {
 }
 
 /// An encoder used to transform a [Value] to bytes, its much like [JsonEncoder] but wrapped with an arc to make it easier.
+#[derive(Clone, Debug)]
 pub struct EasyJsonEncoder {
     encoder: Arc<JsonEncoder<'static>>,
 }

--- a/src/async_impl/easy_proto_decoder.rs
+++ b/src/async_impl/easy_proto_decoder.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 /// A decoder used to transform bytes to a [Value], its much like [ProtoDecoder] but wrapped with an arc to make it easier.
 /// The mean use of this way of decoding is if you don't know the format at compile time.
 /// If you do know the format it's better to use the ProtoRawDecoder, and use a different library to deserialize just the proto bytes.
+#[derive(Clone, Debug)]
 pub struct EasyProtoDecoder {
     decoder: Arc<ProtoDecoder<'static>>,
 }


### PR DESCRIPTION
Make sure there is a related issues, and the docs and unit tests are also updated.

extension of #161 to support cloning / debug for all easy encoders / decoders

Without clone on Arc structs, its strength of passing around smart pointers is greatly diminished. Following #163 to add support for all remaining easy encoders / decoders