### PR TITLE
feat: Support schema_compatibility checking

### DIFF
--- a/src/async_impl/schema_registry.rs
+++ b/src/async_impl/schema_registry.rs
@@ -10,6 +10,7 @@ use futures::stream::{self, StreamExt};
 use reqwest::header::{HeaderName, ACCEPT, CONTENT_TYPE};
 use reqwest::{header, RequestBuilder, Response};
 use reqwest::{Client, ClientBuilder};
+use serde::Deserialize;
 use serde_json::{json, Map, Value};
 
 use crate::error::SRCError;
@@ -610,6 +611,136 @@ async fn perform_single_versions_call(
         .json::<Vec<u32>>()
         .await
         .map_err(|e| SRCError::non_retryable_with_cause(e, "could not parse to list of versions"))
+}
+
+#[derive(Debug, Deserialize)]
+struct CompatibilityResponse {
+    is_compatible: bool,
+}
+
+async fn perform_single_compatibility_call(
+    base_url: &str,
+    client: &Client,
+    authentication: &SrAuthorization,
+    subject: &String,
+    body: &String,
+) -> Result<CompatibilityResponse, SRCError> {
+    let url = format!("{}/compatibility/subjects/{}/versions", base_url, subject);
+    let builder = client
+        .post(url)
+        .body(String::from(body))
+        .header(CONTENT_TYPE, "application/vnd.schemaregistry.v1+json")
+        .header(ACCEPT, "application/vnd.schemaregistry.v1+json");
+    let successful_response = send_with_auth(builder, authentication).await?;
+    successful_response.json().await.map_err(|e| {
+        SRCError::non_retryable_with_cause(e, "could not parse compatibility response")
+    })
+}
+
+async fn perform_compatibility_call(
+    sr_settings: &SrSettings,
+    subject: &String,
+    body: &String,
+) -> Result<CompatibilityResponse, SRCError> {
+    let url_count = sr_settings.urls.len();
+    let mut n = 0;
+    loop {
+        let result = perform_single_compatibility_call(
+            &sr_settings.urls[n],
+            &sr_settings.client,
+            &sr_settings.authorization,
+            subject,
+            body,
+        )
+        .await;
+        if result.is_ok() || n + 1 == url_count {
+            break result;
+        }
+        n += 1
+    }
+}
+
+async fn is_compatible_reference(
+    sr_settings: &SrSettings,
+    schema_type: &str,
+    reference: SuppliedReference,
+) -> Result<Option<RegisteredReference>, SRCError> {
+    let mut references = Vec::new();
+    for r in reference.references {
+        match Box::pin(is_compatible_reference(sr_settings, schema_type, r)).await? {
+            Some(v) => references.push(v),
+            None => return Ok(None),
+        }
+    }
+    let body = get_body(
+        schema_type,
+        &reference.schema,
+        &references,
+        reference.properties.as_ref(),
+        reference.tags.as_ref(),
+    )
+    .await;
+    if !perform_compatibility_call(sr_settings, &reference.subject, &body)
+        .await?
+        .is_compatible
+    {
+        return Ok(None);
+    }
+    let version = call_and_get_version(
+        sr_settings,
+        SrCall::PostForVersion(&reference.subject, &body),
+    )
+    .await?;
+    Ok(Some(RegisteredReference {
+        name: reference.name,
+        subject: reference.subject,
+        version,
+        properties: reference.properties,
+        tags: reference.tags,
+    }))
+}
+
+/// Checks if the supplied schema, including all its references, is compatible with one or more
+/// versions in the subjects based on the configured compatibility level of the subject.
+///
+/// For example, if compatibility on the subject is set to BACKWARD, FORWARD, or FULL, the
+/// compatibility check is against the latest version. If compatibility is set to one of the
+/// TRANSITIVE types, the check is against all previous versions.
+pub async fn is_compatible_schema(
+    sr_settings: &SrSettings,
+    subject: String,
+    schema: SuppliedSchema,
+) -> Result<bool, SRCError> {
+    let schema_type = match &schema.schema_type {
+        SchemaType::Avro => String::from("AVRO"),
+        SchemaType::Protobuf => String::from("PROTOBUF"),
+        SchemaType::Json => String::from("JSON"),
+        SchemaType::Other(v) => v.clone(),
+    };
+    let mut references = Vec::new();
+    for reference in schema.references {
+        match Box::pin(is_compatible_reference(
+            sr_settings,
+            &schema_type,
+            reference,
+        ))
+        .await?
+        {
+            Some(v) => references.push(v),
+            None => return Ok(false),
+        }
+    }
+    let body = get_body(
+        &schema_type,
+        &schema.schema,
+        &references,
+        schema.properties.as_ref(),
+        schema.tags.as_ref(),
+    )
+    .await;
+    Ok(perform_compatibility_call(sr_settings, &subject, &body)
+        .await?
+        .is_compatible)
 }
 
 #[cfg(test)]

--- a/src/blocking/schema_registry.rs
+++ b/src/blocking/schema_registry.rs
@@ -7,6 +7,7 @@ use dashmap::DashMap;
 use reqwest::blocking::{Client, ClientBuilder, RequestBuilder, Response};
 use reqwest::header;
 use reqwest::header::{HeaderName, ACCEPT, CONTENT_TYPE};
+use serde::Deserialize;
 use serde_json::{json, Map, Value};
 
 use crate::error::SRCError;
@@ -549,6 +550,109 @@ fn perform_single_versions_call(
             "could not parse to list of versions, the http call failed, cause will give more information",
         )
     })
+}
+
+#[derive(Debug, Deserialize)]
+struct CompatibilityResponse {
+    is_compatible: bool,
+}
+
+fn perform_single_compatibility_call(
+    base_url: &str,
+    client: &Client,
+    authentication: &SrAuthorization,
+    subject: &String,
+    body: &String,
+) -> Result<CompatibilityResponse, SRCError> {
+    let url = format!("{}/compatibility/subjects/{}/versions", base_url, subject);
+    let builder = client
+        .post(url)
+        .body(String::from(body))
+        .header(CONTENT_TYPE, "application/vnd.schemaregistry.v1+json")
+        .header(ACCEPT, "application/vnd.schemaregistry.v1+json");
+    let successful_response = send_with_auth(builder, authentication)?;
+    successful_response.json().map_err(|e| {
+        SRCError::non_retryable_with_cause(e, "could not parse compatibility response")
+    })
+}
+
+fn perform_compatibility_call(
+    sr_settings: &SrSettings,
+    subject: &String,
+    body: &String,
+) -> Result<CompatibilityResponse, SRCError> {
+    let url_count = sr_settings.urls.len();
+    let mut n = 0;
+    loop {
+        let result = perform_single_compatibility_call(
+            &sr_settings.urls[n],
+            &sr_settings.client,
+            &sr_settings.authorization,
+            subject,
+            body,
+        );
+        if result.is_ok() || n + 1 == url_count {
+            break result;
+        }
+        n += 1
+    }
+}
+
+fn is_compatible_reference(
+    sr_settings: &SrSettings,
+    schema_type: &str,
+    reference: SuppliedReference,
+) -> Result<Option<RegisteredReference>, SRCError> {
+    let mut references = Vec::new();
+    for r in reference.references {
+        match is_compatible_reference(sr_settings, schema_type, r)? {
+            Some(v) => references.push(v),
+            None => return Ok(None),
+        }
+    }
+    let body = get_body(schema_type, &reference.schema, &references);
+    if !perform_compatibility_call(sr_settings, &reference.subject, &body)?.is_compatible {
+        return Ok(None);
+    }
+    let version = call_and_get_version(
+        sr_settings,
+        SrCall::PostForVersion(&reference.subject, &body),
+    )?;
+    Ok(Some(RegisteredReference {
+        name: reference.name,
+        subject: reference.subject,
+        version,
+        properties: reference.properties,
+        tags: reference.tags,
+    }))
+}
+
+/// Checks if the supplied schema, including all its references, is compatible with one or more
+/// versions in the subjects based on the configured compatibility level of the subject.
+///
+/// For example, if compatibility on the subject is set to BACKWARD, FORWARD, or FULL, the
+/// compatibility check is against the latest version. If compatibility is set to one of the
+/// TRANSITIVE types, the check is against all previous versions.
+pub fn is_compatible_schema(
+    sr_settings: &SrSettings,
+    subject: String,
+    schema: SuppliedSchema,
+) -> Result<bool, SRCError> {
+    let schema_type = match &schema.schema_type {
+        SchemaType::Avro => String::from("AVRO"),
+        SchemaType::Protobuf => String::from("PROTOBUF"),
+        SchemaType::Json => String::from("JSON"),
+        SchemaType::Other(v) => v.clone(),
+    };
+    let mut references = Vec::new();
+    for reference in schema.references {
+        match is_compatible_reference(sr_settings, &schema_type, reference)? {
+            Some(v) => references.push(v),
+            None => return Ok(false),
+        }
+    }
+    let body = get_body(&schema_type, &schema.schema, &references);
+    Ok(perform_compatibility_call(sr_settings, &subject, &body)?.is_compatible)
 }
 
 #[cfg(test)]

--- a/tests/async_impl/schema_registry_calls.rs
+++ b/tests/async_impl/schema_registry_calls.rs
@@ -1,8 +1,11 @@
 use schema_registry_converter::async_impl::schema_registry::{
-    get_all_subjects, get_all_versions, perform_sr_call, SrSettings,
+    get_all_subjects, get_all_versions, get_referenced_schema, get_schema_by_subject,
+    is_compatible_schema, perform_sr_call, SrSettings,
 };
 use schema_registry_converter::error::SRCError;
-use schema_registry_converter::schema_registry_common::SrCall;
+use schema_registry_converter::schema_registry_common::{
+    RegisteredReference, SrCall, SubjectNameStrategy, SuppliedReference, SuppliedSchema,
+};
 
 fn get_schema_registry_url() -> String {
     String::from("http://localhost:8081")
@@ -62,5 +65,105 @@ async fn test_get_unknown_schema() {
             )),
             false
         )
+    );
+}
+
+async fn to_supplied_reference(
+    sr_settings: &SrSettings,
+    registered_reference: &RegisteredReference,
+) -> SuppliedReference {
+    let reference_schema = get_referenced_schema(sr_settings, registered_reference)
+        .await
+        .unwrap();
+    SuppliedReference {
+        name: registered_reference.name.clone(),
+        subject: registered_reference.subject.clone(),
+        schema: reference_schema.schema,
+        references: futures::future::join_all(
+            reference_schema
+                .references
+                .iter()
+                .map(|r| to_supplied_reference(sr_settings, r)),
+        )
+        .await,
+        properties: reference_schema.properties,
+        tags: reference_schema.tags,
+    }
+}
+
+#[tokio::test]
+async fn test_check_schema_compatibility_pass() {
+    let sr_settings = SrSettings::new_builder(get_schema_registry_url())
+        .no_proxy()
+        .build()
+        .unwrap();
+    let schema_subject = String::from("testavro-value");
+    let compatibility_check_subject = schema_subject.clone();
+    let schema = get_schema_by_subject(
+        &sr_settings,
+        &SubjectNameStrategy::RecordNameStrategy(schema_subject),
+    )
+    .await
+    .unwrap();
+    let compatible = is_compatible_schema(
+        &sr_settings,
+        compatibility_check_subject,
+        SuppliedSchema {
+            name: None,
+            schema_type: schema.schema_type,
+            schema: schema.schema,
+            references: futures::future::join_all(
+                schema
+                    .references
+                    .iter()
+                    .map(|r| to_supplied_reference(&sr_settings, r)),
+            )
+            .await,
+            properties: schema.properties,
+            tags: schema.tags,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(compatible, "Identical schema should be compatible");
+}
+
+#[tokio::test]
+async fn test_check_schema_compatibility_fail() {
+    let sr_settings = SrSettings::new_builder(get_schema_registry_url())
+        .no_proxy()
+        .build()
+        .unwrap();
+    let schema_subject = String::from("avro-result");
+    let compatibility_check_subject = String::from("testavro-value");
+    let schema = get_schema_by_subject(
+        &sr_settings,
+        &SubjectNameStrategy::RecordNameStrategy(schema_subject),
+    )
+    .await
+    .unwrap();
+    let compatible = is_compatible_schema(
+        &sr_settings,
+        compatibility_check_subject,
+        SuppliedSchema {
+            name: None,
+            schema_type: schema.schema_type,
+            schema: schema.schema,
+            references: futures::future::join_all(
+                schema
+                    .references
+                    .iter()
+                    .map(|r| to_supplied_reference(&sr_settings, r)),
+            )
+            .await,
+            properties: schema.properties,
+            tags: schema.tags,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        !compatible,
+        "avro-result schema should not be compatible with testavro-value"
     );
 }

--- a/tests/blocking/schema_registry_calls.rs
+++ b/tests/blocking/schema_registry_calls.rs
@@ -1,9 +1,12 @@
 use crate::blocking::proto_tests::get_schema_registry_url;
 use schema_registry_converter::blocking::schema_registry::{
-    get_all_subjects, get_all_versions, perform_sr_call, SrSettings,
+    get_all_subjects, get_all_versions, get_referenced_schema, get_schema_by_subject,
+    is_compatible_schema, perform_sr_call, SrSettings,
 };
 use schema_registry_converter::error::SRCError;
-use schema_registry_converter::schema_registry_common::SrCall;
+use schema_registry_converter::schema_registry_common::{
+    RegisteredReference, SrCall, SubjectNameStrategy, SuppliedReference, SuppliedSchema,
+};
 
 #[test]
 fn test_get_all_subjects() {
@@ -57,5 +60,93 @@ fn test_get_unknown_schema() {
             )),
             false
         )
+    );
+}
+
+fn to_supplied_reference(
+    sr_settings: &SrSettings,
+    registered_reference: &RegisteredReference,
+) -> SuppliedReference {
+    let reference_schema = get_referenced_schema(sr_settings, registered_reference).unwrap();
+    SuppliedReference {
+        name: registered_reference.name.clone(),
+        subject: registered_reference.subject.clone(),
+        schema: reference_schema.schema,
+        references: reference_schema
+            .references
+            .iter()
+            .map(|r| to_supplied_reference(sr_settings, r))
+            .collect(),
+        properties: reference_schema.properties,
+        tags: reference_schema.tags,
+    }
+}
+
+#[test]
+fn test_check_schema_compatibility_pass() {
+    let sr_settings = SrSettings::new_builder(get_schema_registry_url())
+        .no_proxy()
+        .build()
+        .unwrap();
+    let schema_subject = String::from("testavro-value");
+    let compatibility_check_subject = schema_subject.clone();
+    let schema = get_schema_by_subject(
+        &sr_settings,
+        &SubjectNameStrategy::RecordNameStrategy(schema_subject),
+    )
+    .unwrap();
+    let compatible = is_compatible_schema(
+        &sr_settings,
+        compatibility_check_subject,
+        SuppliedSchema {
+            name: None,
+            schema_type: schema.schema_type,
+            schema: schema.schema,
+            references: schema
+                .references
+                .iter()
+                .map(|r| to_supplied_reference(&sr_settings, r))
+                .collect(),
+            properties: schema.properties,
+            tags: schema.tags,
+        },
+    )
+    .unwrap();
+    assert!(compatible, "Identical schema should be compatible");
+}
+
+#[test]
+fn test_check_schema_compatibility_fail() {
+    let sr_settings = SrSettings::new_builder(get_schema_registry_url())
+        .no_proxy()
+        .build()
+        .unwrap();
+    let schema_subject = String::from("avro-result");
+    let compatibility_check_subject = String::from("testavro-value");
+    let schema = get_schema_by_subject(
+        &sr_settings,
+        &SubjectNameStrategy::RecordNameStrategy(schema_subject),
+    )
+    .unwrap();
+    let compatible = is_compatible_schema(
+        &sr_settings,
+        compatibility_check_subject,
+        SuppliedSchema {
+            name: None,
+            schema_type: schema.schema_type,
+            schema: schema.schema,
+            references: schema
+                .references
+                .iter()
+                .map(|r| to_supplied_reference(&sr_settings, r))
+                .collect(),
+            properties: schema.properties,
+            tags: schema.tags,
+        },
+    )
+    .unwrap();
+    assert!(
+        !compatible,
+        "avro-result schema should not be compatible with testavro-value"
     );
 }


### PR DESCRIPTION
Hi, sorry that I don't have an attached issue but I will give a quick summary below.

Adding support for [test-schema-compatibility-against-all-schemas-under-a-subject](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#test-schema-compatibility-against-all-schemas-under-a-subject).

The use case is I would like some way to check if my schema is compatible to be newly registered to with the current schema registry's schema evolution strategy (without actually potentially registering the schema)

Currently, `get_schema_by_subject` when using a `RecordName` strategy may actually write to the schema registry https://github.com/gklijs/schema_registry_converter/blob/529c2cacb2f1f1432a406cec7daf73bf9834a619/src/async_impl/schema_registry.rs#L240, so this new function is required if you want to do checks without potentially mutating state (and to not break current behavior by changing the function internal logic, although imo `get_schema_by_subject` is somewhat misleading in thinking its a read only call.

 Please lmk if you have any questions. Thanks!