### PR TITLE
feat: expose subject and version on RegisteredSchema, AvroSchema and …

### DIFF
--- a/src/async_impl/avro.rs
+++ b/src/async_impl/avro.rs
@@ -619,6 +619,8 @@ async fn to_avro_schema(
             id: registered_schema.id,
             raw: registered_schema.schema,
             parsed,
+            subject: registered_schema.subject,
+            version: registered_schema.version,
         })),
         Err(e) => Err(SRCError::non_retryable_with_cause(
             e,
@@ -1570,6 +1572,8 @@ mod tests {
             references: vec![],
             properties: None,
             tags: None,
+            subject: None,
+            version: None,
         };
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
         let result = to_avro_schema(&sr_settings, registered_schema)
@@ -1592,6 +1596,8 @@ mod tests {
             references: vec![],
             properties: None,
             tags: None,
+            subject: None,
+            version: None,
         };
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
         let err = to_avro_schema(&sr_settings, registered_schema)
@@ -1601,6 +1607,27 @@ mod tests {
             err,
             SRCError::new("type Protobuf, is not supported", None, false)
         )
+    }
+
+    #[tokio::test]
+    async fn to_avro_schema_propagates_subject_and_version() {
+        let registered_schema = RegisteredSchema {
+            id: 7,
+            schema_type: SchemaType::Avro,
+            schema: String::from(r#"{"type":"record","name":"X","fields":[]}"#),
+            references: vec![],
+            properties: None,
+            tags: None,
+            subject: Some("orders-value".to_string()),
+            version: Some(3),
+        };
+        let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
+        let avro = to_avro_schema(&sr_settings, registered_schema)
+            .await
+            .expect("conversion succeeds for empty references");
+        assert_eq!(avro.id, 7);
+        assert_eq!(avro.subject.as_deref(), Some("orders-value"));
+        assert_eq!(avro.version, Some(3));
     }
 
     #[tokio::test]

--- a/src/async_impl/json.rs
+++ b/src/async_impl/json.rs
@@ -135,12 +135,18 @@ pub fn validate(schema: JsonSchema, value: &Value) -> Result<(), SRCError> {
 
 /// Schema as retrieved from the schema registry. It's close to the json received and doesn't do
 /// type specific transformations.
+///
+/// `subject` and `version` are populated when the registry response includes them. See
+/// [`crate::schema_registry_common::RegisteredSchema`] for the caveats — a schema id can be
+/// registered against multiple subjects.
 #[derive(Clone, Debug)]
 pub struct JsonSchema {
     pub id: u32,
     pub url: Url,
     pub schema: Value,
     pub references: Vec<JsonSchema>,
+    pub subject: Option<String>,
+    pub version: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -277,6 +283,8 @@ fn to_json_schema(
             url,
             schema,
             references,
+            subject: registered_schema.subject,
+            version: registered_schema.version,
         })
     }
     .boxed()
@@ -297,14 +305,37 @@ mod tests {
 
     use serde_json::Value;
 
-    use crate::async_impl::json::{validate, JsonDecoder, JsonEncoder};
+    use crate::async_impl::json::{to_json_schema, validate, JsonDecoder, JsonEncoder};
     use crate::async_impl::schema_registry::SrSettings;
-    use crate::schema_registry_common::{get_payload, SubjectNameStrategy};
+    use crate::schema_registry_common::{
+        get_payload, RegisteredSchema, SchemaType, SubjectNameStrategy,
+    };
     use test_utils::{
         get_json_body, get_json_body_with_reference, json_get_result_references,
         json_incorrect_bytes, json_result_java_bytes, json_result_schema,
         json_result_schema_with_id, json_test_ref_schema,
     };
+
+    #[tokio::test]
+    async fn to_json_schema_propagates_subject_and_version() {
+        let registered_schema = RegisteredSchema {
+            id: 7,
+            schema_type: SchemaType::Json,
+            schema: r#"{"type":"object"}"#.to_string(),
+            references: vec![],
+            properties: None,
+            tags: None,
+            subject: Some("orders-value".to_string()),
+            version: Some(3),
+        };
+        let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
+        let json_schema = to_json_schema(&sr_settings, None, registered_schema)
+            .await
+            .expect("conversion succeeds for empty references");
+        assert_eq!(json_schema.id, 7);
+        assert_eq!(json_schema.subject.as_deref(), Some("orders-value"));
+        assert_eq!(json_schema.version, Some(3));
+    }
 
     #[tokio::test]
     async fn test_encode_java_compatibility() {

--- a/src/async_impl/schema_registry.rs
+++ b/src/async_impl/schema_registry.rs
@@ -297,6 +297,8 @@ async fn raw_to_registered_schema(
         references,
         properties,
         tags,
+        subject: raw_schema.subject,
+        version: raw_schema.version,
     })
 }
 
@@ -346,6 +348,8 @@ pub async fn post_schema(
         references,
         properties: schema.properties,
         tags: schema.tags,
+        subject: Some(subject),
+        version: None,
     })
 }
 
@@ -961,6 +965,8 @@ mod tests {
                 );
                 tags
             }),
+            subject: Some("ietf-telemetry-message".to_string()),
+            version: Some(1),
         };
 
         let parsed: RawRegisteredSchema = serde_json::from_str(json_str).expect("parse json");

--- a/src/avro_common.rs
+++ b/src/avro_common.rs
@@ -13,11 +13,17 @@ use crate::schema_registry_common::{get_payload, SchemaType, SuppliedSchema};
 
 /// Because we need both the resulting schema, as have a way of posting the schema as json, we use
 /// this struct so we keep them both together.
+///
+/// `subject` and `version` are populated when the registry response includes them. See
+/// [`crate::schema_registry_common::RegisteredSchema`] for the caveats — a schema id can be
+/// registered against multiple subjects.
 #[derive(Debug, PartialEq)]
 pub struct AvroSchema {
     pub id: u32,
     pub raw: String,
     pub parsed: Schema,
+    pub subject: Option<String>,
+    pub version: Option<u32>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -200,6 +206,8 @@ mod tests {
             id: 5,
             raw: "".to_string(),
             parsed: Schema::Boolean,
+            subject: None,
+            version: None,
         };
         let result = values_to_bytes(&schema, vec![("beat", Value::Long(3))]);
         assert_eq!(
@@ -218,6 +226,8 @@ mod tests {
             id: 5,
             raw: String::from(r#"{"type":"record","name":"Name","namespace":"nl.openweb.data","fields":[{"name":"name","type":"string","avro.java.string":"String"}]}"#),
             parsed: Schema::parse_str(r#"{"type":"record","name":"Name","namespace":"nl.openweb.data","fields":[{"name":"name","type":"string","avro.java.string":"String"}]}"#).unwrap(),
+            subject: None,
+            version: None,
         };
         let err = values_to_bytes(&schema, vec![("beat", Value::Long(3))]).unwrap_err();
         assert_eq!(err.error, "Could not get Avro bytes")
@@ -233,6 +243,8 @@ mod tests {
             parsed: Schema::parse_str(
                 r#"{"type":"record","name":"Name","namespace":"nl.openweb.data","fields":[{"name":"name","type":"string","avro.java.string":"String"}]}"#,
             ).unwrap(),
+            subject: None,
+            version: None,
         };
         let err = crate::avro_common::item_to_bytes(&schema, Heartbeat { beat: 3 }).unwrap_err();
         assert_eq!(err.error, "Failed to resolve")
@@ -248,6 +260,8 @@ mod tests {
             parsed: Schema::parse_str(
                 r#"{"type":"record","name":"ConfirmAccountCreation","namespace":"nl.openweb.data","fields":[{"name":"id","type":{"type":"fixed","name":"Uuid","size":16}},{"name":"a_type","type":{"type":"enum","name":"Atype","symbols":["AUTO","MANUAL"]}}]}"#,
             ).unwrap(),
+            subject: None,
+            version: None,
         };
         let item = ConfirmAccountCreation {
             id: [

--- a/src/blocking/avro.rs
+++ b/src/blocking/avro.rs
@@ -553,6 +553,8 @@ fn to_avro_schema(
             id: registered_schema.id,
             raw: registered_schema.schema,
             parsed,
+            subject: registered_schema.subject,
+            version: registered_schema.version,
         })),
         Err(e) => Err(SRCError::non_retryable_with_cause(
             e,
@@ -1464,6 +1466,8 @@ mod tests {
             references: vec![],
             properties: None,
             tags: None,
+            subject: None,
+            version: None,
         };
         let sr_settings = SrSettings::new_builder(String::from("http://127.0.0.1:1234"))
             .no_proxy()
@@ -1487,6 +1491,8 @@ mod tests {
             references: vec![],
             properties: None,
             tags: None,
+            subject: None,
+            version: None,
         };
         let sr_settings = SrSettings::new_builder(String::from("http://127.0.0.1:1234"))
             .no_proxy()
@@ -1500,6 +1506,29 @@ mod tests {
             result,
             SRCError::new("type Protobuf, is not supported", None, false)
         )
+    }
+
+    #[test]
+    fn to_avro_schema_propagates_subject_and_version() {
+        let registered_schema = RegisteredSchema {
+            id: 7,
+            schema_type: SchemaType::Avro,
+            schema: String::from(r#"{"type":"record","name":"X","fields":[]}"#),
+            references: vec![],
+            properties: None,
+            tags: None,
+            subject: Some("orders-value".to_string()),
+            version: Some(3),
+        };
+        let sr_settings = SrSettings::new_builder(String::from("http://127.0.0.1:1234"))
+            .no_proxy()
+            .build()
+            .unwrap();
+        let avro = to_avro_schema(&sr_settings, registered_schema)
+            .expect("conversion succeeds for empty references");
+        assert_eq!(avro.id, 7);
+        assert_eq!(avro.subject.as_deref(), Some("orders-value"));
+        assert_eq!(avro.version, Some(3));
     }
 
     #[test]

--- a/src/blocking/schema_registry.rs
+++ b/src/blocking/schema_registry.rs
@@ -290,6 +290,8 @@ fn raw_to_registered_schema(
         references,
         properties,
         tags,
+        subject: raw_schema.subject,
+        version: raw_schema.version,
     })
 }
 
@@ -331,6 +333,8 @@ pub fn post_schema(
         references,
         properties: schema.properties,
         tags: schema.tags,
+        subject: Some(subject),
+        version: None,
     })
 }
 
@@ -876,6 +880,8 @@ mod tests {
                 );
                 tags
             }),
+            subject: Some("ietf-tls-common".to_string()),
+            version: Some(1),
         };
 
         let parsed: RawRegisteredSchema = serde_json::from_str(json_str).expect("parse json");

--- a/src/schema_registry_common.rs
+++ b/src/schema_registry_common.rs
@@ -85,6 +85,11 @@ pub struct RegisteredReference {
 
 /// Schema as retrieved from the schema registry. It's close to the json received and doesn't do
 /// type specific transformations.
+///
+/// `subject` and `version` are populated from the registry response when available. The Confluent
+/// Schema Registry includes them in `GET /schemas/ids/{id}` responses; an id can be registered
+/// against multiple subjects, so the value here is "the subject the registry returned" rather than
+/// an authoritative single answer. Use `GET /schemas/ids/{id}/subjects` if you need the full set.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RegisteredSchema {
     pub id: u32,
@@ -93,6 +98,8 @@ pub struct RegisteredSchema {
     pub references: Vec<RegisteredReference>,
     pub properties: Option<HashMap<String, String>>,
     pub tags: Option<HashMap<String, Vec<String>>>,
+    pub subject: Option<String>,
+    pub version: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -349,6 +356,8 @@ mod test {
             references: vec![],
             properties: None,
             tags: None,
+            subject: None,
+            version: None,
         };
         assert_eq!(0, registered_schema.id);
         assert_eq!(SchemaType::Avro, registered_schema.schema_type);
@@ -356,8 +365,10 @@ mod test {
         assert!(registered_schema.references.is_empty());
         assert!(registered_schema.properties.is_none());
         assert!(registered_schema.tags.is_none());
+        assert!(registered_schema.subject.is_none());
+        assert!(registered_schema.version.is_none());
         assert_eq!(
-            r#"RegisteredSchema { id: 0, schema_type: Avro, schema: "some schema", references: [], properties: None, tags: None }"#,
+            r#"RegisteredSchema { id: 0, schema_type: Avro, schema: "some schema", references: [], properties: None, tags: None, subject: None, version: None }"#,
             format!("{:?}", registered_schema)
         )
     }


### PR DESCRIPTION
Confluent's GET /schemas/ids/{id} returns subject and version in the response body. The library already deserializes them into RawRegisteredSchema (Option<String> / Option<u32>), then drops both during the conversion to RegisteredSchema. Consumers that want to log or observe which registration served a decoded record currently have to make a second HTTP call to recover information that already arrived in the first one.

This patch propagates those fields through to RegisteredSchema and onto the leaf decoder types AvroSchema and JsonSchema.

A schema id can be registered against multiple subjects, and Confluent exposes GET /schemas/ids/{id}/subjects (returns an array) for callers that need the full set. But GET /schemas/ids/{id} returns one specific (subject, version) pair by design. The response shape documents these as scalar fields, not arrays. The registry returns a representative registration tied to the schema's lookup path (typically the originating one, or the one matched by ?subject=...).

We surface what the registry chose to return. The doc comment on the struct says so explicitly so callers do not mistake the field for an authoritative single answer:

> subject and version are populated when the registry response includes them. A schema id can be registered against multiple subjects, so the value here is the registration the registry returned, not necessarily the only answer. Use GET /schemas/ids/{id}/subjects for the full set.

Callers that need exhaustive subject lookup are not blocked by this change; they can call /schemas/ids/{id}/subjects themselves. Callers that just want a human-readable coordinate get one for free.