### PR TITLE
Two fixes related to error caching

### DIFF
--- a/schema_registry_converter.allium
+++ b/schema_registry_converter.allium
@@ -558,7 +558,12 @@ rule RejectSchemaOfWrongFormat {
     requires: data.format != entry.codec.format
     ensures:
         entry.status = failed
-        entry.error = format_mismatch_error(data.format, entry.codec.format)
+        entry.error = as_cached(format_mismatch_error(data.format, entry.codec.format))
+
+    @guidance
+        -- A format mismatch can never be fixed by retrying the same call, so unlike a
+        -- retriable resolution failure it is always cached, the same as
+        -- RecordFailedResolution's non-retriable branch.
 }
 
 -- Referenced schemas are fetched by subject and version, depth first, and each one may
@@ -602,27 +607,37 @@ rule ResolveEntryOnceReferencesFetched {
         entry.schema = schema
 }
 
--- A reference that cannot be fetched fails the entire resolution, and that failure is
--- what gets cached against the top-level key.
+-- A reference that cannot be fetched fails the entire resolution. If the failure is
+-- retriable, nothing is cached; otherwise that failure is what gets cached against the
+-- top-level key.
 rule ReferenceFetchFailsResolution {
     when: RegistryReferenceFetchFailed(entry, pointer, error)
     requires: entry.status = in_flight
     ensures:
-        entry.status = failed
-        entry.error = as_cached(error)
+        if error.retriable:
+            not exists entry
+        else:
+            entry.status = failed
+            entry.error = as_cached(error)
 }
 
 rule RecordFailedResolution {
     when: RegistryCallFailed(entry, error)
     requires: entry.status = in_flight
     ensures:
-        entry.status = failed
-        entry.error = as_cached(error)
+        if error.retriable:
+            not exists entry
+        else:
+            entry.status = failed
+            entry.error = as_cached(error)
 
     @guidance
         -- as_cached marks the error as cached. A cached failure is never retried on its
         -- own: the caller must clear cached errors before the same key will reach the
-        -- registry again.
+        -- registry again. A retriable failure is the opposite: nothing about it is worth
+        -- remembering, so the entry is discarded outright rather than settling into
+        -- failed, and the very next call for the same key starts a completely fresh
+        -- resolution attempt with no explicit clear required.
 }
 
 rule ClearCachedErrors {
@@ -632,7 +647,9 @@ rule ClearCachedErrors {
             not exists entry
 
     @guidance
-        -- Successful cache entries are left untouched.
+        -- Successful cache entries are left untouched. failed_entries only ever holds
+        -- non-retriable failures: a retriable one never settles into failed in the first
+        -- place, so there is nothing here for this call to find and clear on its behalf.
 }
 
 -- --- Encoding --------------------------------------------------------------
@@ -1034,9 +1051,11 @@ surface AsyncCodecOperations {
         demands FormatCodec
 
     @guarantee CachedFailuresRequireExplicitClear
-        -- A resolution failure is cached exactly like a success. The same key will not
-        -- reach the registry again until the caller clears cached errors, which leaves
-        -- successful entries in place.
+        -- A non-retriable resolution failure is cached exactly like a success: the same
+        -- key will not reach the registry again until the caller clears cached errors,
+        -- which leaves successful entries in place. A retriable failure is not cached at
+        -- all -- nothing persists, so the very next call for the same key starts a fresh
+        -- resolution attempt automatically, with no explicit clear required.
 
     @guarantee SharedInFlightResolution
         -- Concurrent callers asking for the same not-yet-cached key produce one registry
@@ -1067,9 +1086,11 @@ surface BlockingCodecOperations {
         demands FormatCodec
 
     @guarantee CachedFailuresRequireExplicitClear
-        -- A resolution failure is cached exactly like a success. The same key will not
-        -- reach the registry again until the caller clears cached errors, which leaves
-        -- successful entries in place.
+        -- A non-retriable resolution failure is cached exactly like a success: the same
+        -- key will not reach the registry again until the caller clears cached errors,
+        -- which leaves successful entries in place. A retriable failure is not cached at
+        -- all -- nothing persists, so the very next call for the same key starts a fresh
+        -- resolution attempt automatically, with no explicit clear required.
 
     @guarantee SharedInFlightResolution
         -- Concurrent callers asking for the same not-yet-cached key produce one registry

--- a/src/async_impl/avro.rs
+++ b/src/async_impl/avro.rs
@@ -92,9 +92,11 @@ type SharedFutureSchema<'a> = Shared<BoxFuture<'a, Result<Arc<AvroSchema>, SRCEr
 impl<'a> AvroDecoder<'a> {
     /// Creates a new decoder which will use the supplied url to fetch the schema's since the schema
     /// needed is encoded in the binary, independent of the SubjectNameStrategy we don't need any
-    /// additional data. It's possible for recoverable errors to stay in the cash, when a result
-    /// comes back as an error you can use remove_errors_from_cache to clean the cache, keeping the
-    /// correctly fetched schema's
+    /// additional data. Retriable errors (e.g. a transient network/HTTP failure) are never cached,
+    /// so those are simply retried on the next call. Non-retriable errors (e.g. a schema that
+    /// doesn't exist or can't be parsed) are cached to avoid repeatedly retrying a lookup that
+    /// isn't going to succeed; if the underlying problem gets fixed you can use
+    /// remove_errors_from_cache to clean those out.
     pub fn new(sr_settings: SrSettings) -> AvroDecoder<'a> {
         AvroDecoder {
             sr_settings,
@@ -102,9 +104,10 @@ impl<'a> AvroDecoder<'a> {
             cache: DashMap::new(),
         }
     }
-    /// Remove al the errors from the cache, you might need to/want to run this when a recoverable
-    /// error is met. Errors are also cashed to prevent trying to get schema's that either don't
-    /// exist or can't be parsed.
+    /// Removes all non-retriable errors from the cache. You might need/want to run this when the
+    /// underlying problem has been fixed (e.g. a schema was missing and has since been
+    /// registered) and want the next call to try again immediately. Retriable errors aren't
+    /// stored in the cache in the first place, so there's nothing to remove for those.
     ///
     /// ```
     /// use apache_avro::types::Value;
@@ -245,11 +248,23 @@ impl<'a> AvroDecoder<'a> {
         match self.direct_cache.get(&id) {
             None => {
                 let result = self.get_schema_by_shared_future(id).await;
-                if result.is_ok() && !self.direct_cache.contains_key(&id) {
-                    self.direct_cache.insert(id, result.clone().unwrap());
-                    self.cache.remove(&id);
-                };
-                result
+                match result {
+                    Ok(v) => {
+                        if !self.direct_cache.contains_key(&id) {
+                            self.direct_cache.insert(id, v.clone());
+                            self.cache.remove(&id);
+                        }
+                        Ok(v)
+                    }
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is dropped and the next call issues a fresh request
+                    // rather than replaying a stale failure.
+                    Err(e) if e.retriable => {
+                        self.cache.remove(&id);
+                        Err(e)
+                    }
+                    Err(e) => Err(e.into_cache()),
+                }
             }
             Some(result) => Ok(result.value().clone()),
         }
@@ -265,7 +280,7 @@ impl<'a> AvroDecoder<'a> {
                         Ok(registered_schema) => {
                             to_avro_schema(&sr_settings, registered_schema).await
                         }
-                        Err(e) => Err(e.into_cache()),
+                        Err(e) => Err(e),
                     }
                 }
                 .boxed()
@@ -377,9 +392,10 @@ impl<'a> AvroEncoder<'a> {
             cache: DashMap::new(),
         }
     }
-    /// Remove al the errors from the cache, you might need to/want to run this when a recoverable
-    /// error is met. Errors are also cashed to prevent trying to get schema's that either don't
-    /// exist or can't be parsed.
+    /// Removes all non-retriable errors from the cache. You might need/want to run this when the
+    /// underlying problem has been fixed (e.g. a schema was missing and has since been
+    /// registered) and want the next call to try again immediately. Retriable errors aren't
+    /// stored in the cache in the first place, so there's nothing to remove for those.
     ///
     /// ```
     /// use apache_avro::types::Value;
@@ -461,10 +477,7 @@ impl<'a> AvroEncoder<'a> {
         subject_name_strategy: SubjectNameStrategy,
     ) -> Result<Vec<u8>, SRCError> {
         let key = subject_name_strategy.get_subject()?;
-        let schema = self
-            .get_schema_and_id_by_shared_future(key, subject_name_strategy)
-            .clone()
-            .await?;
+        let schema = self.get_schema_and_id(&key, subject_name_strategy).await?;
         values_to_bytes(&schema, values)
     }
 
@@ -551,12 +564,23 @@ impl<'a> AvroEncoder<'a> {
                 let result = self
                     .get_schema_and_id_by_shared_future(key.to_string(), subject_name_strategy)
                     .await;
-                if result.is_ok() && !self.direct_cache.contains_key(key) {
-                    self.direct_cache
-                        .insert(key.to_string(), result.clone().unwrap());
-                    self.cache.remove(key);
-                };
-                result
+                match result {
+                    Ok(v) => {
+                        if !self.direct_cache.contains_key(key) {
+                            self.direct_cache.insert(key.to_string(), v.clone());
+                            self.cache.remove(key);
+                        }
+                        Ok(v)
+                    }
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is dropped and the next call issues a fresh request
+                    // rather than replaying a stale failure.
+                    Err(e) if e.retriable => {
+                        self.cache.remove(key);
+                        Err(e)
+                    }
+                    Err(e) => Err(e.into_cache()),
+                }
             }
             Some(result) => Ok(result.value().clone()),
         }
@@ -576,7 +600,7 @@ impl<'a> AvroEncoder<'a> {
                         Ok(registered_schema) => {
                             to_avro_schema(&sr_settings, registered_schema).await
                         }
-                        Err(e) => Err(e.into_cache()),
+                        Err(e) => Err(e),
                     }
                 }
                 .boxed()
@@ -1046,6 +1070,78 @@ mod tests {
         )
     }
 
+    #[tokio::test]
+    async fn test_decoder_conversion_error_is_cached() {
+        // Regression test for https://github.com/gklijs/schema_registry_converter/issues/175:
+        // an error from the schema-conversion step (not just the registry lookup) must be
+        // flagged as `cached: true`, the same as a lookup error is.
+        let mut server = Server::new_async().await;
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = AvroDecoder::new(sr_settings);
+        let bytes = [0, 0, 0, 0, 3, 6];
+
+        let _m = server
+            .mock("GET", "/schemas/ids/3?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"schema":"not valid json"}"#)
+            .create();
+
+        let err = decoder.decode(Some(&bytes)).await.unwrap_err();
+        assert!(
+            err.cached,
+            "conversion-step error should be flagged as cached, got {:?}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decoder_retriable_error_is_not_cached() {
+        // Regression test for https://github.com/gklijs/schema_registry_converter/issues/171:
+        // a retriable error (e.g. a transient 503) must not stick around in the cache, so the
+        // very next call succeeds without needing remove_errors_from_cache().
+        let mut server = Server::new_async().await;
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = AvroDecoder::new(sr_settings);
+        let bytes = [0, 0, 0, 0, 9, 6];
+
+        let _m = server
+            .mock("GET", "/schemas/ids/9?deleted=true")
+            .with_status(503)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"error_code":50302,"message":"Leader not known"}"#)
+            .create();
+
+        let err = decoder.decode(Some(&bytes)).await.unwrap_err();
+        assert!(err.retriable, "expected a retriable error, got {:?}", err);
+        assert!(
+            !err.cached,
+            "retriable error should not be cached, got {:?}",
+            err
+        );
+
+        let _m = server
+            .mock("GET", "/schemas/ids/9?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
+            .create();
+
+        // No remove_errors_from_cache() call: this must succeed purely because the retriable
+        // error above was never cached in the first place.
+        let heartbeat = decoder.decode(Some(&bytes)).await.unwrap().value;
+        assert_eq!(
+            heartbeat,
+            Value::Record(vec![("beat".to_string(), Value::Long(3))])
+        )
+    }
+
     #[test]
     fn display_encoder() {
         let sr_settings = SrSettings::new_builder(String::from("http://127.0.0.1:1234"))
@@ -1236,6 +1332,7 @@ mod tests {
             .await
             .unwrap_err();
 
+        // Retriable errors (transient network/HTTP issues) aren't cached — see issue #171.
         assert_eq!(
             err,
             SRCError::new(
@@ -1243,7 +1340,6 @@ mod tests {
                 Some(String::from("builder error for url (hxxx://bogus/subjects/heartbeat-nl.openweb.data.Balance/versions/latest)")),
                 true,
             )
-                .into_cache()
         )
     }
 
@@ -1540,6 +1636,7 @@ mod tests {
             .encode(vec![("beat", Value::Long(3))], strategy)
             .await
             .unwrap_err();
+        // Retriable errors (transient network/HTTP issues) aren't cached — see issue #171.
         assert_eq!(
             error,
             SRCError::new(
@@ -1549,7 +1646,6 @@ mod tests {
                 )),
                 true,
             )
-            .into_cache()
         )
     }
 

--- a/src/async_impl/json.rs
+++ b/src/async_impl/json.rs
@@ -46,7 +46,8 @@ impl<'a> JsonEncoder<'a> {
             cache: DashMap::new(),
         }
     }
-    /// Removes errors from the cache, can be usefull to retry failed encodings.
+    /// Removes all non-retriable errors from the cache, useful to retry failed encodings once
+    /// the underlying problem has been fixed. Retriable errors aren't cached in the first place.
     pub fn remove_errors_from_cache(&self) {
         self.cache.retain(|_, v| match v.peek() {
             Some(r) => r.is_ok(),
@@ -77,12 +78,23 @@ impl<'a> JsonEncoder<'a> {
                 let result = self
                     .get_schema_by_shared_future(key.clone(), subject_name_strategy)
                     .await;
-                if result.is_ok() && !self.direct_cache.contains_key(&key) {
-                    self.direct_cache
-                        .insert(key.clone(), result.clone().unwrap());
-                    self.cache.remove(&key);
-                };
-                result
+                match result {
+                    Ok(v) => {
+                        if !self.direct_cache.contains_key(&key) {
+                            self.direct_cache.insert(key.clone(), v.clone());
+                            self.cache.remove(&key);
+                        }
+                        Ok(v)
+                    }
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is dropped and the next call issues a fresh request
+                    // rather than replaying a stale failure.
+                    Err(e) if e.retriable => {
+                        self.cache.remove(&key);
+                        Err(e)
+                    }
+                    Err(e) => Err(e.into_cache()),
+                }
             }
             Some(result) => Ok(result.value().clone()),
         }
@@ -103,7 +115,7 @@ impl<'a> JsonEncoder<'a> {
                             Ok(s) => Ok(Arc::new(s)),
                             Err(e) => Err(e),
                         },
-                        Err(e) => Err(e.into_cache()),
+                        Err(e) => Err(e),
                     }
                 }
                 .boxed()
@@ -166,9 +178,11 @@ pub struct JsonDecoder<'a> {
 impl<'a> JsonDecoder<'a> {
     /// Creates a new decoder which will use the supplied url to fetch the schema's since the schema
     /// needed is encoded in the binary, independent of the SubjectNameStrategy we don't need any
-    /// additional data. It's possible for recoverable errors to stay in the cache, when a result
-    /// comes back as an error you can use remove_errors_from_cache to clean the cache, keeping the
-    /// correctly fetched schema's
+    /// additional data. Retriable errors (e.g. a transient network/HTTP failure) are never cached,
+    /// so those are simply retried on the next call. Non-retriable errors (e.g. a schema that
+    /// doesn't exist or can't be parsed) are cached to avoid repeatedly retrying a lookup that
+    /// isn't going to succeed; if the underlying problem gets fixed you can use
+    /// remove_errors_from_cache to clean those out.
     pub fn new(sr_settings: SrSettings) -> JsonDecoder<'a> {
         JsonDecoder {
             sr_settings,
@@ -176,9 +190,10 @@ impl<'a> JsonDecoder<'a> {
             cache: DashMap::new(),
         }
     }
-    /// Remove al the errors from the cache, you might need to/want to run this when a recoverable
-    /// error is met. Errors are also cashed to prevent trying to get schema's that either don't
-    /// exist or can't be parsed.
+    /// Removes all non-retriable errors from the cache. You might need/want to run this when the
+    /// underlying problem has been fixed (e.g. a schema was missing and has since been
+    /// registered) and want the next call to try again immediately. Retriable errors aren't
+    /// stored in the cache in the first place, so there's nothing to remove for those.
     pub fn remove_errors_from_cache(&self) {
         self.cache.retain(|_, v| match v.peek() {
             Some(r) => r.is_ok(),
@@ -215,11 +230,23 @@ impl<'a> JsonDecoder<'a> {
         match self.direct_cache.get(&id) {
             None => {
                 let result = self.get_schema_by_shared_future(id).await;
-                if result.is_ok() && !self.direct_cache.contains_key(&id) {
-                    self.direct_cache.insert(id, result.clone().unwrap());
-                    self.cache.remove(&id);
-                };
-                result
+                match result {
+                    Ok(v) => {
+                        if !self.direct_cache.contains_key(&id) {
+                            self.direct_cache.insert(id, v.clone());
+                            self.cache.remove(&id);
+                        }
+                        Ok(v)
+                    }
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is dropped and the next call issues a fresh request
+                    // rather than replaying a stale failure.
+                    Err(e) if e.retriable => {
+                        self.cache.remove(&id);
+                        Err(e)
+                    }
+                    Err(e) => Err(e.into_cache()),
+                }
             }
             Some(result) => Ok(result.value().clone()),
         }
@@ -238,7 +265,7 @@ impl<'a> JsonDecoder<'a> {
                             Ok(v) => Ok(Arc::new(v)),
                             Err(e) => Err(e),
                         },
-                        Err(e) => Err(e.into_cache()),
+                        Err(e) => Err(e),
                     }
                 }
                 .boxed()

--- a/src/async_impl/proto_decoder.rs
+++ b/src/async_impl/proto_decoder.rs
@@ -28,9 +28,11 @@ pub struct ProtoDecoder<'a> {
 impl<'a> ProtoDecoder<'a> {
     /// Creates a new decoder which will use the supplied url used in creating the sr settings to
     /// fetch the schema's since the schema needed is encoded in the binary, independent of the
-    /// SubjectNameStrategy we don't need any additional data. It's possible for recoverable errors
-    /// to stay in the cache, when a result comes back as an error you can use
-    /// remove_errors_from_cache to clean the cache, keeping the correctly fetched schema's
+    /// SubjectNameStrategy we don't need any additional data. Retriable errors (e.g. a transient
+    /// network/HTTP failure) are never cached, so those are simply retried on the next call.
+    /// Non-retriable errors (e.g. a schema that doesn't exist or can't be parsed) are cached to
+    /// avoid repeatedly retrying a lookup that isn't going to succeed; if the underlying problem
+    /// gets fixed you can use remove_errors_from_cache to clean those out.
     pub fn new(sr_settings: SrSettings) -> ProtoDecoder<'a> {
         ProtoDecoder {
             sr_settings,
@@ -38,9 +40,10 @@ impl<'a> ProtoDecoder<'a> {
             cache: DashMap::new(),
         }
     }
-    /// Remove all the errors from the cache, you might need to/want to run this when a recoverable
-    /// error is met. Errors are also cashed to prevent trying to get schema's that either don't
-    /// exist or can't be parsed.
+    /// Removes all non-retriable errors from the cache. You might need/want to run this when the
+    /// underlying problem has been fixed (e.g. a schema was missing and has since been
+    /// registered) and want the next call to try again immediately. Retriable errors aren't
+    /// stored in the cache in the first place, so there's nothing to remove for those.
     pub fn remove_errors_from_cache(&self) {
         self.cache.retain(|_, v| match v.peek() {
             Some(r) => r.is_ok(),
@@ -119,11 +122,23 @@ impl<'a> ProtoDecoder<'a> {
         match self.direct_cache.get(&id) {
             None => {
                 let result = self.get_vec_of_schemas_by_shared_future(id).await;
-                if result.is_ok() && !self.direct_cache.contains_key(&id) {
-                    self.direct_cache.insert(id, result.clone().unwrap());
-                    self.cache.remove(&id);
-                };
-                result
+                match result {
+                    Ok(v) => {
+                        if !self.direct_cache.contains_key(&id) {
+                            self.direct_cache.insert(id, v.clone());
+                            self.cache.remove(&id);
+                        }
+                        Ok(v)
+                    }
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is dropped and the next call issues a fresh request
+                    // rather than replaying a stale failure.
+                    Err(e) if e.retriable => {
+                        self.cache.remove(&id);
+                        Err(e)
+                    }
+                    Err(e) => Err(e.into_cache()),
+                }
             }
             Some(result) => Ok(result.value().clone()),
         }
@@ -139,7 +154,7 @@ impl<'a> ProtoDecoder<'a> {
                 let v = async move {
                     match get_schema_by_id_and_type(id, &sr_settings, SchemaType::Protobuf).await {
                         Ok(v) => to_vec_of_schemas(&sr_settings, v).await,
-                        Err(e) => Err(e.into_cache()),
+                        Err(e) => Err(e),
                     }
                 }
                 .boxed()
@@ -180,6 +195,15 @@ pub struct DecodeContext {
     pub context: Context,
 }
 
+/// Parses the schema texts into a `DecodeContext`. Deliberately *not* cached: unlike the
+/// blocking decoder (which caches the parsed `Arc<DecodeContext>` and so also caches a parse
+/// failure), this runs again on every `deserialize`/`deserialize_with_context` call, re-parsing
+/// on each decode rather than storing the parsed `Context`/`MessageResolver` in the schema-id
+/// cache alongside the raw schema texts. That's an intentional trade-off to avoid caching
+/// non-trivial parsed state, not an oversight — see
+/// https://github.com/gklijs/schema_registry_converter/issues/175 for the discussion. One
+/// consequence: a parse failure here is never cached, so `error.cached` is always `false` for
+/// it and it's retried on every call, unlike the equivalent blocking-decoder failure.
 fn into_decode_context(mut vec_of_schemas: Vec<String>) -> Result<DecodeContext, SRCError> {
     // The root schema is always pushed last by add_files, so pop it off rather than
     // re-parsing it below with the other, dependent schemas.

--- a/src/blocking/avro.rs
+++ b/src/blocking/avro.rs
@@ -87,18 +87,21 @@ pub struct AvroDecoder {
 impl AvroDecoder {
     /// Creates a new decoder which will use the supplied url to fetch the schema's since the schema
     /// needed is encoded in the binary, independent of the SubjectNameStrategy we don't need any
-    /// additional data. It's possible for recoverable errors to stay in the cash, when a result
-    /// comes back as an error you can use remove_errors_from_cache to clean the cache, keeping the
-    /// correctly fetched schema's
+    /// additional data. Retriable errors (e.g. a transient network/HTTP failure) are never cached,
+    /// so those are simply retried on the next call. Non-retriable errors (e.g. a schema that
+    /// doesn't exist or can't be parsed) are cached to avoid repeatedly retrying a lookup that
+    /// isn't going to succeed; if the underlying problem gets fixed you can use
+    /// remove_errors_from_cache to clean those out.
     pub fn new(sr_settings: SrSettings) -> AvroDecoder {
         AvroDecoder {
             sr_settings,
             cache: DashMap::new(),
         }
     }
-    /// Remove al the errors from the cache, you might need to/want to run this when a recoverable
-    /// error is met. Errors are also cashed to prevent trying to get schema's that either don't
-    /// exist or can't be parsed.
+    /// Removes all non-retriable errors from the cache. You might need/want to run this when the
+    /// underlying problem has been fixed (e.g. a schema was missing and has since been
+    /// registered) and want the next call to try again immediately. Retriable errors aren't
+    /// stored in the cache in the first place, so there's nothing to remove for those.
     ///
     /// ```
     /// use apache_avro::types::Value;
@@ -236,13 +239,22 @@ impl AvroDecoder {
     fn schema(&self, id: u32) -> Result<Arc<AvroSchema>, SRCError> {
         let sr_settings = &self.sr_settings;
         match self.cache.entry(id) {
-            Entry::Occupied(e) => e.get().clone(),
-            Entry::Vacant(e) => {
-                let v = match get_schema_by_id_and_type(id, sr_settings, SchemaType::Avro) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let result = match get_schema_by_id_and_type(id, sr_settings, SchemaType::Avro) {
                     Ok(registered_schema) => to_avro_schema(sr_settings, registered_schema),
-                    Err(e) => Err(e.into_cache()),
+                    Err(e) => Err(e),
                 };
-                e.insert(v).value().clone()
+                match result {
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is left vacant and the next call issues a fresh
+                    // request rather than replaying a stale failure.
+                    Err(e) if e.retriable => Err(e),
+                    result => entry
+                        .insert(result.map_err(SRCError::into_cache))
+                        .value()
+                        .clone(),
+                }
             }
         }
     }
@@ -339,9 +351,10 @@ impl AvroEncoder {
             cache: DashMap::new(),
         }
     }
-    /// Remove al the errors from the cache, you might need to/want to run this when a recoverable
-    /// error is met. Errors are also cashed to prevent trying to get schema's that either don't
-    /// exist or can't be parsed.
+    /// Removes all non-retriable errors from the cache. You might need/want to run this when the
+    /// underlying problem has been fixed (e.g. a schema was missing and has since been
+    /// registered) and want the next call to try again immediately. Retriable errors aren't
+    /// stored in the cache in the first place, so there's nothing to remove for those.
     ///
     /// ```
     /// use apache_avro::types::Value;
@@ -483,13 +496,22 @@ impl AvroEncoder {
     ) -> Result<Arc<AvroSchema>, SRCError> {
         let sr_settings = &self.sr_settings;
         match self.cache.entry(key) {
-            Entry::Occupied(e) => e.get().clone(),
-            Entry::Vacant(e) => {
-                let v = match get_schema_by_subject(sr_settings, subject_name_strategy) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let result = match get_schema_by_subject(sr_settings, subject_name_strategy) {
                     Ok(registered_schema) => to_avro_schema(sr_settings, registered_schema),
-                    Err(e) => Err(e.into_cache()),
+                    Err(e) => Err(e),
                 };
-                e.insert(v).value().clone()
+                match result {
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is left vacant and the next call issues a fresh
+                    // request rather than replaying a stale failure.
+                    Err(e) if e.retriable => Err(e),
+                    result => entry
+                        .insert(result.map_err(SRCError::into_cache))
+                        .value()
+                        .clone(),
+                }
             }
         }
     }
@@ -972,6 +994,50 @@ mod tests {
     }
 
     #[test]
+    fn test_decoder_retriable_error_is_not_cached() {
+        // Regression test for https://github.com/gklijs/schema_registry_converter/issues/171:
+        // a retriable error (e.g. a transient 503) must not stick around in the cache, so the
+        // very next call succeeds without needing remove_errors_from_cache().
+        let mut server = mockito::Server::new();
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = AvroDecoder::new(sr_settings);
+        let bytes = [0, 0, 0, 0, 9, 6];
+
+        let _m = server
+            .mock("GET", "/schemas/ids/9?deleted=true")
+            .with_status(503)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"error_code":50302,"message":"Leader not known"}"#)
+            .create();
+
+        let err = decoder.decode(Some(&bytes)).unwrap_err();
+        assert!(err.retriable, "expected a retriable error, got {:?}", err);
+        assert!(
+            !err.cached,
+            "retriable error should not be cached, got {:?}",
+            err
+        );
+
+        let _m = server
+            .mock("GET", "/schemas/ids/9?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
+            .create();
+
+        // No remove_errors_from_cache() call: this must succeed purely because the retriable
+        // error above was never cached in the first place.
+        let heartbeat = decoder.decode(Some(&bytes)).unwrap().value;
+        assert_eq!(
+            heartbeat,
+            Value::Record(vec![("beat".to_string(), Value::Long(3))])
+        )
+    }
+
+    #[test]
     fn display_encoder() {
         let sr_settings = SrSettings::new_builder(String::from("http://127.0.0.1:1234"))
             .no_proxy()
@@ -1148,14 +1214,14 @@ mod tests {
         );
         let result = encoder.encode(vec![("beat", Value::Long(3))], &strategy);
 
+        // Retriable errors (transient network/HTTP issues) aren't cached — see issue #171.
         assert_eq!(
             result,
             Err(SRCError::new(
                 "http call to schema registry failed",
                 Some(String::from("builder error for url (hxxx://bogus/subjects/heartbeat-nl.openweb.data.Balance/versions/latest)")),
                 true,
-            )
-                .into_cache())
+            ))
         )
     }
 
@@ -1434,6 +1500,7 @@ mod tests {
         let error = encoder
             .encode(vec![("beat", Value::Long(3))], &strategy)
             .unwrap_err();
+        // Retriable errors (transient network/HTTP issues) aren't cached — see issue #171.
         assert_eq!(
             error,
             SRCError::new(
@@ -1443,7 +1510,6 @@ mod tests {
                 )),
                 true,
             )
-            .into_cache()
         )
     }
 

--- a/src/blocking/json.rs
+++ b/src/blocking/json.rs
@@ -37,7 +37,8 @@ impl JsonEncoder {
             scope: Scope::new(),
         }
     }
-    /// Removes errors from the cache, can be useful to retry failed encodings.
+    /// Removes all non-retriable errors from the cache, useful to retry failed encodings once
+    /// the underlying problem has been fixed. Retriable errors aren't cached in the first place.
     pub fn remove_errors_from_cache(&mut self) {
         self.cache.retain(|_, v| v.is_ok());
     }
@@ -62,9 +63,9 @@ impl JsonEncoder {
         value: &Value,
     ) -> Result<(ValidationState, u32), SRCError> {
         let cached_context = match self.cache.entry(key) {
-            Entry::Occupied(e) => e.into_mut().as_ref(),
-            Entry::Vacant(e) => {
-                let v = match get_schema_by_subject(&self.sr_settings, subject_name_strategy) {
+            Entry::Occupied(entry) => entry.into_mut().as_ref(),
+            Entry::Vacant(entry) => {
+                let result = match get_schema_by_subject(&self.sr_settings, subject_name_strategy) {
                     Ok(registered_schema) => match set_scoped_schema(
                         &mut self.scope,
                         &self.sr_settings,
@@ -74,11 +75,17 @@ impl JsonEncoder {
                             id: registered_schema.id,
                             url,
                         }),
-                        Err(e) => Err(e.into_cache()),
+                        Err(e) => Err(e),
                     },
-                    Err(e) => Err(e.into_cache()),
+                    Err(e) => Err(e),
                 };
-                e.insert(v).as_ref()
+                match result {
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is left vacant and the next call issues a fresh
+                    // request rather than replaying a stale failure.
+                    Err(e) if e.retriable => return Err(e),
+                    result => entry.insert(result.map_err(SRCError::into_cache)).as_ref(),
+                }
             }
         };
         match cached_context {
@@ -109,9 +116,11 @@ pub struct JsonDecoder {
 impl JsonDecoder {
     /// Creates a new decoder which will use the supplied url to fetch the schema's since the schema
     /// needed is encoded in the binary, independent of the SubjectNameStrategy we don't need any
-    /// additional data. It's possible for recoverable errors to stay in the cache, when a result
-    /// comes back as an error you can use remove_errors_from_cache to clean the cache, keeping the
-    /// correctly fetched schema's
+    /// additional data. Retriable errors (e.g. a transient network/HTTP failure) are never cached,
+    /// so those are simply retried on the next call. Non-retriable errors (e.g. a schema that
+    /// doesn't exist or can't be parsed) are cached to avoid repeatedly retrying a lookup that
+    /// isn't going to succeed; if the underlying problem gets fixed you can use
+    /// remove_errors_from_cache to clean those out.
     pub fn new(sr_settings: SrSettings) -> JsonDecoder {
         JsonDecoder {
             sr_settings,
@@ -119,9 +128,10 @@ impl JsonDecoder {
             scope: Scope::new(),
         }
     }
-    /// Remove al the errors from the cache, you might need to/want to run this when a recoverable
-    /// error is met. Errors are also cashed to prevent trying to get schema's that either don't
-    /// exist or can't be parsed.
+    /// Removes all non-retriable errors from the cache. You might need/want to run this when the
+    /// underlying problem has been fixed (e.g. a schema was missing and has since been
+    /// registered) and want the next call to try again immediately. Retriable errors aren't
+    /// stored in the cache in the first place, so there's nothing to remove for those.
     pub fn remove_errors_from_cache(&mut self) {
         self.cache.retain(|_, v| v.is_ok());
     }
@@ -151,16 +161,23 @@ impl JsonDecoder {
     /// it into the cache.
     fn schema(&mut self, id: u32) -> Result<ScopedSchema, SRCError> {
         let url = match self.cache.entry(id) {
-            Entry::Occupied(e) => &*e.into_mut(),
-            Entry::Vacant(e) => {
-                let v = match get_schema_by_id_and_type(id, &self.sr_settings, SchemaType::Json) {
-                    Ok(r) => match set_scoped_schema(&mut self.scope, &self.sr_settings, &r) {
-                        Ok(schema) => Ok(schema),
-                        Err(e) => Err(e.into_cache()),
-                    },
-                    Err(e) => Err(e.into_cache()),
-                };
-                &*e.insert(v)
+            Entry::Occupied(entry) => &*entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let result =
+                    match get_schema_by_id_and_type(id, &self.sr_settings, SchemaType::Json) {
+                        Ok(r) => match set_scoped_schema(&mut self.scope, &self.sr_settings, &r) {
+                            Ok(schema) => Ok(schema),
+                            Err(e) => Err(e),
+                        },
+                        Err(e) => Err(e),
+                    };
+                match result {
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is left vacant and the next call issues a fresh
+                    // request rather than replaying a stale failure.
+                    Err(e) if e.retriable => return Err(e),
+                    result => &*entry.insert(result.map_err(SRCError::into_cache)),
+                }
             }
         };
         match url {
@@ -249,10 +266,10 @@ mod tests {
     use crate::json_common::handle_validation;
     use crate::schema_registry_common::{get_payload, SubjectNameStrategy};
     use test_utils::{
-        get_json_body, get_json_body_with_reference, json_extra_schema,
-        json_get_extra_references, json_get_result_references, json_incorrect_bytes,
-        json_result_java_bytes, json_result_schema, json_result_schema_with_id,
-        json_test_ref_schema, json_test_ref_schema_with_extra,
+        get_json_body, get_json_body_with_reference, json_extra_schema, json_get_extra_references,
+        json_get_result_references, json_incorrect_bytes, json_result_java_bytes,
+        json_result_schema, json_result_schema_with_id, json_test_ref_schema,
+        json_test_ref_schema_with_extra,
     };
 
     #[test]

--- a/src/blocking/proto_decoder.rs
+++ b/src/blocking/proto_decoder.rs
@@ -23,18 +23,21 @@ pub struct ProtoDecoder {
 impl ProtoDecoder {
     /// Creates a new decoder which will use the supplied url used in creating the sr settings to
     /// fetch the schema's since the schema needed is encoded in the binary, independent of the
-    /// SubjectNameStrategy we don't need any additional data. It's possible for recoverable errors
-    /// to stay in the cache, when a result comes back as an error you can use
-    /// remove_errors_from_cache to clean the cache, keeping the correctly fetched schema's
+    /// SubjectNameStrategy we don't need any additional data. Retriable errors (e.g. a transient
+    /// network/HTTP failure) are never cached, so those are simply retried on the next call.
+    /// Non-retriable errors (e.g. a schema that doesn't exist or can't be parsed) are cached to
+    /// avoid repeatedly retrying a lookup that isn't going to succeed; if the underlying problem
+    /// gets fixed you can use remove_errors_from_cache to clean those out.
     pub fn new(sr_settings: SrSettings) -> ProtoDecoder {
         ProtoDecoder {
             sr_settings,
             cache: DashMap::new(),
         }
     }
-    /// Remove al the errors from the cache, you might need to/want to run this when a recoverable
-    /// error is met. Errors are also cashed to prevent trying to get schema's that either don't
-    /// exist or can't be parsed.
+    /// Removes all non-retriable errors from the cache. You might need/want to run this when the
+    /// underlying problem has been fixed (e.g. a schema was missing and has since been
+    /// registered) and want the next call to try again immediately. Retriable errors aren't
+    /// stored in the cache in the first place, so there's nothing to remove for those.
     pub fn remove_errors_from_cache(&self) {
         self.cache.retain(|_, v| v.is_ok());
     }
@@ -112,14 +115,26 @@ impl ProtoDecoder {
     /// it into the cache.
     fn context(&self, id: u32) -> Result<Arc<DecodeContext>, SRCError> {
         match self.cache.entry(id) {
-            Entry::Occupied(e) => e.get().clone(),
-            Entry::Vacant(e) => {
-                let v = match get_schema_by_id_and_type(id, &self.sr_settings, SchemaType::Protobuf)
-                {
-                    Ok(v) => to_resolve_context(&self.sr_settings, v),
-                    Err(e) => Err(e.into_cache()),
-                };
-                e.insert(v).value().clone()
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let result =
+                    match get_schema_by_id_and_type(id, &self.sr_settings, SchemaType::Protobuf) {
+                        Ok(v) => to_resolve_context(&self.sr_settings, v),
+                        Err(e) => Err(e),
+                    };
+                match result {
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is left vacant and the next call issues a fresh
+                    // request rather than replaying a stale failure. Non-retriable errors,
+                    // e.g. a parse failure, are cached permanently. Unlike the async decoder,
+                    // this caches the fully-parsed Context rather than re-parsing on every
+                    // decode call — see https://github.com/gklijs/schema_registry_converter/issues/175.
+                    Err(e) if e.retriable => Err(e),
+                    result => entry
+                        .insert(result.map_err(SRCError::into_cache))
+                        .value()
+                        .clone(),
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/gklijs/schema_registry_converter/issues/175

Fixes https://github.com/gklijs/schema_registry_converter/issues/171

## What changed

**#175 — `SRCError.cached` was applied inconsistently.** Every codec (async + blocking Avro, JSON Schema, generic Protobuf) only flagged `cached: true` for errors from the initial registry lookup, not for a subsequent failure in schema conversion/parsing — so identical failures reported different `cached` values depending on where in the pipeline they occurred. Every cache-populating call site now flags whichever error actually ends up cached, uniformly.

**#171 — retriable errors were cached like any other failure.** A transient error (network blip, 502/503) used to get stuck in the cache exactly like a permanent one, requiring an explicit `remove_errors_from_cache()` before the next call would even try again. Retriable errors are no longer cached at all: blocking leaves the cache entry vacant, async evicts it from the shared-future cache right after it resolves, so the very next call starts a fresh attempt automatically. No feature flag.

Auditing every cache call site for #171 also turned up a related bug: async `AvroEncoder::encode()` (the `Vec<(&str, Value)>` overload) called the shared-future resolver directly, bypassing the caching wrapper entirely. Fixed as part of this PR too.

## Tests

Added regression tests per codec covering both fixes (conversion-step errors flagged as cached; retriable errors surviving a next call with no explicit clear), verified to fail on the pre-fix code and pass after.

## Spec

Updated `schema_registry_converter.allium`: the `CachedFailuresRequireExplicitClear` guarantee and the resolution-failure rules previously stated every failure is cached unconditionally; they now distinguish retriable from non-retriable. Also reconciled `RejectSchemaOfWrongFormat`, which was the one rule not marking its error as cached, for consistency with the others.
