### PR TITLE
Fix panic on malformed protobuf-framed payloads

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 ## Release notes
 
+### 4.11.0
+
+Fix a panic when decoding a 5-byte (or otherwise malformed/truncated) protobuf-framed payload
+with `ProtoDecoder`/`ProtoRawDecoder` (blocking and async); such payloads now yield an `SRCError`
+instead. As part of this, `proto_resolver::to_index_and_data` is now fallible: it returns
+`Result<(Vec<i32>, Vec<u8>), SRCError>` instead of `(Vec<i32>, Vec<u8>)`, a breaking change for
+any caller using that function directly. Fixes #176.
+
 ### 4.10.0
 
 Propagate properties and tags.

--- a/src/async_impl/proto_decoder.rs
+++ b/src/async_impl/proto_decoder.rs
@@ -69,7 +69,7 @@ impl<'a> ProtoDecoder<'a> {
     async fn deserialize(&self, id: u32, bytes: &[u8]) -> Result<MessageValue, SRCError> {
         let vec_of_schemas = self.get_vec_of_schemas(id).await?;
         let context = into_decode_context(vec_of_schemas.to_vec())?;
-        let (index, data) = to_index_and_data(bytes);
+        let (index, data) = to_index_and_data(bytes)?;
         let full_name = resolve_name(&context.resolver, &index)?;
         let message_info = context.context.get_message(&full_name).unwrap();
         Ok(message_info.decode(&data, &context.context))
@@ -105,7 +105,7 @@ impl<'a> ProtoDecoder<'a> {
     ) -> Result<DecodeResultWithContext, SRCError> {
         let vec_of_schemas = self.get_vec_of_schemas(id).await?;
         let context = into_decode_context(vec_of_schemas.to_vec())?;
-        let (index, data_bytes) = to_index_and_data(bytes);
+        let (index, data_bytes) = to_index_and_data(bytes)?;
         let full_name = resolve_name(&context.resolver, &index)?;
         let message_info = context.context.get_message(&full_name).unwrap();
         let value = message_info.decode(&data_bytes, &context.context);
@@ -243,7 +243,8 @@ mod tests {
     use protofish::prelude::Value;
     use test_utils::{
         get_proto_complex, get_proto_complex_proto_test_message, get_proto_complex_references,
-        get_proto_hb_101, get_proto_hb_schema, get_proto_money_result, get_proto_result,
+        get_proto_hb_101, get_proto_hb_101_empty_payload, get_proto_hb_schema,
+        get_proto_money_result, get_proto_result,
     };
 
     fn get_proto_body(schema: &str, id: u32) -> String {
@@ -283,6 +284,26 @@ mod tests {
         };
 
         assert_eq!(Value::UInt64(101u64), message.fields[0].value)
+    }
+
+    #[tokio::test]
+    async fn test_decoder_five_byte_message_gives_error_instead_of_panic() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = ProtoDecoder::new(sr_settings);
+        let result = decoder.decode(Some(get_proto_hb_101_empty_payload())).await;
+
+        assert!(result.is_err())
     }
 
     #[tokio::test]

--- a/src/async_impl/proto_raw.rs
+++ b/src/async_impl/proto_raw.rs
@@ -168,7 +168,7 @@ impl<'a> ProtoRawDecoder<'a> {
     /// using a reader transforms the bytes to a value.
     async fn deserialize(&self, id: u32, bytes: &[u8]) -> Result<RawDecodeResult, SRCError> {
         let context = self.get_context(id).await?;
-        let (index, data) = to_index_and_data(bytes);
+        let (index, data) = to_index_and_data(bytes)?;
         let full_name = resolve_name(&context.resolver, &index)?;
         let schema = &context.schema;
         Ok(RawDecodeResult {
@@ -229,8 +229,8 @@ mod tests {
     use test_utils::{
         get_proto_body, get_proto_body_with_reference, get_proto_complex,
         get_proto_complex_only_data, get_proto_complex_proto_test_message,
-        get_proto_complex_references, get_proto_hb_101, get_proto_hb_101_only_data,
-        get_proto_hb_schema, get_proto_result,
+        get_proto_complex_references, get_proto_hb_101, get_proto_hb_101_empty_payload,
+        get_proto_hb_101_only_data, get_proto_hb_schema, get_proto_result,
     };
 
     #[tokio::test]
@@ -455,6 +455,26 @@ mod tests {
 
         assert_eq!(raw_result.bytes, get_proto_hb_101_only_data());
         assert_eq!(*raw_result.full_name, "nl.openweb.data.Heartbeat")
+    }
+
+    #[tokio::test]
+    async fn test_decoder_five_byte_message_gives_error_instead_of_panic() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = ProtoRawDecoder::new(sr_settings);
+        let result = decoder.decode(Some(get_proto_hb_101_empty_payload())).await;
+
+        assert!(result.is_err())
     }
 
     #[tokio::test]

--- a/src/blocking/proto_decoder.rs
+++ b/src/blocking/proto_decoder.rs
@@ -60,7 +60,7 @@ impl ProtoDecoder {
     fn deserialize(&self, id: u32, bytes: &[u8]) -> Result<MessageValue, SRCError> {
         match self.context(id) {
             Ok(s) => {
-                let (index, data) = to_index_and_data(bytes);
+                let (index, data) = to_index_and_data(bytes)?;
                 let full_name = resolve_name(&s.resolver, &index)?;
                 let message_info = s.context.get_message(&full_name).unwrap();
                 Ok(message_info.decode(&data, &s.context))
@@ -97,7 +97,7 @@ impl ProtoDecoder {
     ) -> Result<DecodeResultWithContext, SRCError> {
         match self.context(id) {
             Ok(s) => {
-                let (index, data_bytes) = to_index_and_data(bytes);
+                let (index, data_bytes) = to_index_and_data(bytes)?;
                 let full_name = resolve_name(&s.resolver, &index)?;
                 let message_info = s.context.get_message(&full_name).unwrap();
                 let value = message_info.decode(&data_bytes, &s.context);
@@ -207,7 +207,8 @@ mod tests {
     use test_utils::{
         get_proto_body, get_proto_body_with_reference, get_proto_complex,
         get_proto_complex_proto_test_message, get_proto_complex_references, get_proto_hb_101,
-        get_proto_hb_schema, get_proto_money_result, get_proto_result,
+        get_proto_hb_101_empty_payload, get_proto_hb_schema, get_proto_money_result,
+        get_proto_result,
     };
 
     #[test]
@@ -235,6 +236,27 @@ mod tests {
         };
 
         assert_eq!(Value::UInt64(101u64), message.fields[0].value)
+    }
+
+    #[test]
+    fn test_decoder_five_byte_message_gives_error_instead_of_panic() {
+        let mut server = mockito::Server::new();
+
+        let _m = server
+            .mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = ProtoDecoder::new(sr_settings);
+        let result = decoder.decode(Some(get_proto_hb_101_empty_payload()));
+
+        assert!(result.is_err())
     }
 
     #[test]

--- a/src/blocking/proto_raw.rs
+++ b/src/blocking/proto_raw.rs
@@ -125,7 +125,7 @@ impl ProtoRawDecoder {
         match self.context(id) {
             Ok(s) => {
                 let schema = &s.schema;
-                let (index, data) = to_index_and_data(bytes);
+                let (index, data) = to_index_and_data(bytes)?;
                 let full_name = resolve_name(&s.resolver, &index)?;
                 Ok(RawDecodeResult {
                     schema: schema.clone(),
@@ -170,8 +170,8 @@ mod tests {
     use test_utils::{
         get_proto_body, get_proto_body_with_reference, get_proto_complex,
         get_proto_complex_only_data, get_proto_complex_proto_test_message,
-        get_proto_complex_references, get_proto_hb_101, get_proto_hb_101_only_data,
-        get_proto_hb_schema, get_proto_result,
+        get_proto_complex_references, get_proto_hb_101, get_proto_hb_101_empty_payload,
+        get_proto_hb_101_only_data, get_proto_hb_schema, get_proto_result,
     };
 
     #[test]
@@ -393,6 +393,26 @@ mod tests {
 
         assert_eq!(raw_result.bytes, get_proto_hb_101_only_data());
         assert_eq!(*raw_result.full_name, "nl.openweb.data.Heartbeat")
+    }
+
+    #[test]
+    fn test_decoder_five_byte_message_gives_error_instead_of_panic() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = ProtoRawDecoder::new(sr_settings);
+        let result = decoder.decode(Some(get_proto_hb_101_empty_payload()));
+
+        assert!(result.is_err())
     }
 
     #[test]

--- a/src/proto_resolver.rs
+++ b/src/proto_resolver.rs
@@ -184,17 +184,27 @@ fn same_vec(first: &[i32], second: &[i32]) -> bool {
     true
 }
 
-pub fn to_index_and_data(bytes: &[u8]) -> (Vec<i32>, Vec<u8>) {
+pub fn to_index_and_data(bytes: &[u8]) -> Result<(Vec<i32>, Vec<u8>), SRCError> {
+    if bytes.is_empty() {
+        return Err(SRCError::non_retryable_without_cause(
+            "Empty bytes given to decode the message index from",
+        ));
+    }
     if bytes[0] == 0 {
-        (vec![0], bytes[1..].to_vec())
+        Ok((vec![0], bytes[1..].to_vec()))
     } else {
         let mut reader = BufReader::with_capacity(bytes.len(), bytes);
-        let count: i32 = reader.read_varint().unwrap();
+        let count: i32 = reader.read_varint().map_err(|e| {
+            SRCError::non_retryable_with_cause(e, "Could not read the message index count")
+        })?;
         let mut index = Vec::new();
         for _ in 0..count {
-            index.push(reader.read_varint().unwrap())
+            let i = reader.read_varint().map_err(|e| {
+                SRCError::non_retryable_with_cause(e, "Could not read a message index value")
+            })?;
+            index.push(i)
         }
-        (index, reader.buffer().to_vec())
+        Ok((index, reader.buffer().to_vec()))
     }
 }
 
@@ -210,7 +220,7 @@ pub fn resolve_name(resolver: &MessageResolver, index: &[i32]) -> Result<Arc<Str
 
 #[cfg(test)]
 mod tests {
-    use crate::proto_resolver::{IndexResolver, MessageResolver};
+    use crate::proto_resolver::{to_index_and_data, IndexResolver, MessageResolver};
     use std::sync::Arc;
 
     fn get_proto_simple() -> &'static str {
@@ -403,5 +413,36 @@ message Receipts {
         );
         assert_eq!(resolver.find_name(&[1]), None);
         assert_eq!(resolver.imports.len(), 0)
+    }
+
+    #[test]
+    fn to_index_and_data_empty_bytes_gives_error() {
+        // this is what a 5-byte schema-registry-framed message (magic byte + 4-byte id +
+        // zero-length payload) turns into once get_bytes_result strips the header: an empty
+        // slice. This used to panic on `bytes[0]` instead of returning an error.
+        let result = to_index_and_data(&[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn to_index_and_data_truncated_varint_count_gives_error() {
+        // a non-zero first byte signals a varint-encoded index count should follow, but there's
+        // nothing after it; 0x80 has its continuation bit set, so a byte must follow. This used
+        // to panic via `.unwrap()` on the `read_varint()` result.
+        let result = to_index_and_data(&[0x80]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn to_index_and_data_truncated_varint_index_gives_error() {
+        // count (zig-zag decoded) says two index values follow, but only one more byte remains.
+        let result = to_index_and_data(&[4, 5]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn to_index_and_data_single_index_with_data() {
+        let result = to_index_and_data(&[0, 42, 43]);
+        assert_eq!(result, Ok((vec![0], vec![42, 43])));
     }
 }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -41,6 +41,14 @@ pub fn get_proto_hb_101() -> &'static [u8] {
     &[0, 0, 0, 0, 7, 0, 8, 101]
 }
 
+/// A 5-byte schema-registry-framed message: magic byte + 4-byte schema id (7, matching
+/// [`get_proto_hb_schema`]) + zero-length payload. This is the minimum length classified as
+/// `Valid` framing, and used to be able to make the protobuf decoders panic instead of
+/// returning an `SRCError`. See https://github.com/gklijs/schema_registry_converter/issues/176.
+pub fn get_proto_hb_101_empty_payload() -> &'static [u8] {
+    &[0, 0, 0, 0, 7]
+}
+
 pub fn get_proto_complex_only_data() -> &'static [u8] {
     &get_proto_complex_proto_test_message()[7..]
 }


### PR DESCRIPTION
`to_index_and_data` indexed into the payload and unwrapped varint reads unconditionally, so a 5-byte schema-registry-framed message (magic byte + 4-byte id + empty payload), or any payload with a truncated index, crashed the process instead of returning an SRCError. Both ProtoDecoder and ProtoRawDecoder (blocking and async) went through this path.

`to_index_and_data` now returns a Result and bounds-checks the empty case and varint reads, propagated with `?` at all six call sites. This changes its public signature, which is a breaking change for anyone calling it directly (noted in RELEASE_NOTES.md for 4.11.0).

Adds regression tests at the resolver level (e
and through all four decoders (5-byte message no longer panics).

Fixes https://github.com/gklijs/schema_registry_converter/issues/176

Make sure there is a related issues, and the docs and unit tests are also updated.

If this changes behaviour described in `schema_registry_converter.allium`, please update the spec too (or note in the PR why it doesn't need it).
