### PR TITLE
Fix proto resolver desync on brace characters inside string literals

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,12 @@ instead. As part of this, `proto_resolver::to_index_and_data` is now fallible: i
 `Result<(Vec<i32>, Vec<u8>), SRCError>` instead of `(Vec<i32>, Vec<u8>)`, a breaking change for
 any caller using that function directly. Fixes #176.
 
+Fix a follow-up issue in the same area: a brace character inside a string literal in a proto
+schema (e.g. a field/option default value) could desync `MessageResolver`/`IndexResolver`'s
+index bookkeeping from the real message nesting, since its lexer didn't previously recognize
+string literals and treated every `{`/`}` as message nesting. String literals are now skipped as
+a whole when scanning for braces.
+
 ### 4.10.0
 
 Propagate properties and tags.

--- a/check_test_app_done.sh
+++ b/check_test_app_done.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
-for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-  failures=$(docker inspect -f '{{ .State.ExitCode }}' test-app)
-  if [[ "$failures" == "0" ]]; then
+for i in $(seq 1 40); do
+  running=$(docker inspect -f '{{ .State.Running }}' test-app)
+  exit_code=$(docker inspect -f '{{ .State.ExitCode }}' test-app)
+  # A freshly started container also reports ExitCode 0 (its unset default)
+  # while still Running, so we must wait for it to have actually stopped
+  # before trusting the exit code - otherwise this check is a no-op that
+  # always "succeeds" on the very first loop.
+  if [[ "$running" == "false" && "$exit_code" == "0" ]]; then
     echo -e "Successful load java data in loop ${i}"
     exit 0
   fi

--- a/src/proto_resolver.rs
+++ b/src/proto_resolver.rs
@@ -72,13 +72,22 @@ enum Token {
     #[regex(r"//[\w\s]+\n", logos::skip, priority = 20)]
     LineComment,
 
-    #[regex(r"package\s+[a-zA-z0-9\\.\\_]+;", priority = 10)]
+    // Field/option string literals (e.g. a `[default = "{"]`) can contain brace characters.
+    // These need to be skipped as a whole, with higher priority than Open/Close below, so such
+    // braces aren't mistaken for message nesting and don't desync the index bookkeeping.
+    #[regex(r#""(\\.|[^"\\])*""#, logos::skip, priority = 20)]
+    DoubleQuotedString,
+
+    #[regex(r"'(\\.|[^'\\])*'", logos::skip, priority = 20)]
+    SingleQuotedString,
+
+    #[regex(r"package\s+[a-zA-Z0-9\\.\\_]+;", priority = 10)]
     Package,
 
-    #[regex(r"message\s+[a-zA-z0-9\\_]+", priority = 10)]
+    #[regex(r"message\s+[a-zA-Z0-9\\_]+", priority = 10)]
     Message,
 
-    #[regex(r#"import\s+"[a-zA-z0-9\\.\\_/]+";"#, priority = 10)]
+    #[regex(r#"import\s+"[a-zA-Z0-9\\.\\_/]+";"#, priority = 10)]
     Import,
 
     #[token("{", priority = 10)]
@@ -113,7 +122,7 @@ impl ResolverHelper {
                     let slice = lex.slice();
                     let message = String::from(slice[8..slice.len()].trim());
                     for i in &indexes {
-                        if same_vec(i, &index) {
+                        if *i == index {
                             *index.last_mut().unwrap() += 1;
                         }
                     }
@@ -134,7 +143,9 @@ impl ResolverHelper {
                 Err(_)
                 | Ok(Token::Ignorable)
                 | Ok(Token::BlockComment)
-                | Ok(Token::LineComment) => (),
+                | Ok(Token::LineComment)
+                | Ok(Token::DoubleQuotedString)
+                | Ok(Token::SingleQuotedString) => (),
             };
             next = lex.next()
         }
@@ -150,7 +161,7 @@ impl ResolverHelper {
 
 fn find_part<'a>(index: &'a [i32], helper: &'a ResolverHelper) -> &'a str {
     for i in 0..helper.indexes.len() {
-        if same_vec(index, &helper.indexes[i]) {
+        if index == helper.indexes[i] {
             return &helper.names[i];
         }
     }
@@ -170,18 +181,6 @@ fn find_name(index: &[i32], helper: &ResolverHelper) -> String {
         result.push_str(part)
     }
     result
-}
-
-fn same_vec(first: &[i32], second: &[i32]) -> bool {
-    if first.len() != second.len() {
-        return false;
-    };
-    for i in 0..first.len() {
-        if first[i] != second[i] {
-            return false;
-        }
-    }
-    true
 }
 
 pub fn to_index_and_data(bytes: &[u8]) -> Result<(Vec<i32>, Vec<u8>), SRCError> {
@@ -413,6 +412,53 @@ message Receipts {
         );
         assert_eq!(resolver.find_name(&[1]), None);
         assert_eq!(resolver.imports.len(), 0)
+    }
+
+    #[test]
+    fn test_schema_with_brace_in_string_default() {
+        // A brace character inside a string literal (e.g. a default/option value) used to be
+        // mistaken for message nesting, desyncing the index bookkeeping for anything declared
+        // after it.
+        let schema = r#"syntax = "proto3"; message Outer { string weird = 1 [default = "{"]; } message Inner { int32 x = 1; }"#;
+        let resolver = MessageResolver::new(schema);
+        assert_eq!(
+            resolver.find_name(&[0]),
+            Some(Arc::new(String::from("Outer")))
+        );
+        assert_eq!(
+            resolver.find_name(&[1]),
+            Some(Arc::new(String::from("Inner")))
+        );
+    }
+
+    #[test]
+    fn test_schema_with_brace_in_single_quoted_string() {
+        let schema = r#"syntax = "proto3"; message Outer { string weird = 1 [default = '}']; } message Inner { int32 x = 1; }"#;
+        let resolver = MessageResolver::new(schema);
+        assert_eq!(
+            resolver.find_name(&[0]),
+            Some(Arc::new(String::from("Outer")))
+        );
+        assert_eq!(
+            resolver.find_name(&[1]),
+            Some(Arc::new(String::from("Inner")))
+        );
+    }
+
+    #[test]
+    fn test_schema_with_escaped_quote_in_string() {
+        // an escaped quote inside the string shouldn't be mistaken for the closing quote, which
+        // would otherwise leave the rest of the literal (including its brace) unprotected.
+        let schema = r#"syntax = "proto3"; message Outer { string weird = 1 [default = "a\"{"]; } message Inner { int32 x = 1; }"#;
+        let resolver = MessageResolver::new(schema);
+        assert_eq!(
+            resolver.find_name(&[0]),
+            Some(Arc::new(String::from("Outer")))
+        );
+        assert_eq!(
+            resolver.find_name(&[1]),
+            Some(Arc::new(String::from("Inner")))
+        );
     }
 
     #[test]


### PR DESCRIPTION
MessageResolver/IndexResolver's schema lexer treated every `{`/`}` as message nesting, with no concept of string literals. A brace inside a string (e.g. a field/option default like `[default = "{"]`) desynced the index bookkeeping for anything declared afterwards, which could misresolve or fail to resolve legitimately existing messages -- the same brittle-input-handling pattern as the panic fixed for #176, just triggered by schema text rather than wire bytes.

String literals (single- and double-quoted, escape-aware) are now skipped as a whole when scanning for braces, same as comments already were.

Also, while in this file:
- fix a-zA-z -> a-zA-Z typo in the Package/Message/Import regexes (A-z includes 6 stray ASCII punctuation cha
- replace the hand-rolled same_vec helper with direct == comparisons, now that both sides are always Vec<i32>/&[i

Adds regression tests for brace-in-string (bo
escaped-quote-inside-string case.

Make sure there is a related issues, and the docs and unit tests are also updated.

If this changes behaviour described in `schema_registry_converter.allium`, please update the spec too (or note in the PR why it doesn't need it).
