### PR TITLE
Add performance benchmarks for issue 118

### DIFF
--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -1,0 +1,108 @@
+name: Bench compare
+
+# Compares this PR's benchmarks (see https://github.com/gklijs/schema_registry_converter/issues/118)
+# against `main`, and posts/updates a single PR comment with the result. Deliberately separate
+# from ci.yml's own non-gating `benchmarks` step (which only prints numbers for the PR itself):
+# this job needs to check out and build *two* refs, and needs `pull-requests: write` to comment.
+#
+# Uses `pull_request`, not `pull_request_target`: fork PRs get a read-only GITHUB_TOKEN this way,
+# which is the safe choice given the job compiles and runs the PR's own (untrusted) code. The
+# trade-off is that the comment-posting step can't write on a fork PR and is allowed to fail
+# quietly there -- the numbers are still visible in this workflow's own log either way.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: bench-compare-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bench-compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: bench-compare
+
+      - name: Clear any cached criterion data
+        # Swatinem/rust-cache caches target/ (that's the point -- it's what makes the two
+        # full-feature builds below fast) and doesn't know to exclude target/criterion. Without
+        # this, a `main` baseline restored from a *previous* run's cache could still be sitting
+        # there before "Build & benchmark main" below ever runs. That's mostly harmless when
+        # that step succeeds (--save-baseline overwrites it with fresh data either way), but if
+        # it ever fails, the compare step would silently fall back to comparing against that
+        # stale leftover instead of correctly reporting "no baseline". Wiping it here guarantees
+        # every comparison is provably built by *this* run, never left over from a previous one.
+        run: rm -rf target/criterion
+
+      - name: Note PR commit
+        run: echo "PR_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Benchmark PR (plain)
+        # No --baseline here: this can't panic on a missing baseline (see run_bench_pass.sh),
+        # so it's the guaranteed-complete source of "current" timings for every benchmark,
+        # including ones this PR adds that main doesn't have yet.
+        run: |
+          mkdir -p bench-artifacts
+          bash scripts/run_bench_pass.sh plain > bench-artifacts/plain.txt 2>&1
+        continue-on-error: true
+
+      - name: Build & benchmark main
+        run: |
+          git fetch origin main:refs/remotes/origin/main --depth 1
+          git checkout --detach origin/main
+          bash scripts/run_bench_pass.sh save-baseline main > bench-artifacts/main_build.txt 2>&1
+        continue-on-error: true
+
+      - name: Back to PR code
+        run: git checkout --detach "$PR_SHA"
+
+      - name: Compare PR against main
+        run: bash scripts/run_bench_pass.sh compare main bench-artifacts
+        continue-on-error: true
+
+      - name: Render comparison
+        run: |
+          python3 scripts/bench_compare.py bench-artifacts/plain.txt bench-artifacts/compare_*.txt \
+            > bench-artifacts/comment.md || echo \
+            "_Benchmark comparison could not be generated -- see this workflow's log for details._" \
+            > bench-artifacts/comment.md
+
+      - name: Post/update PR comment
+        if: always()
+        continue-on-error: true # best-effort: fork PRs get a read-only token and can't comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('bench-artifacts/comment.md', 'utf8');
+            const marker = '<!-- schema-registry-converter-bench-compare -->';
+            const comment = `${marker}\n## 📊 Benchmark comparison vs \`main\`\n\n${body}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment,
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,9 @@ jobs:
         run: cargo test --verbose --all-features -- --test-threads=1
       - name: ci-flow
         run: cargo make --makefile make.toml ci-flow
+      - name: benchmarks
+        # See https://github.com/gklijs/schema_registry_converter/issues/118. Shared runners are
+        # too noisy for reliable pass/fail thresholds, so this just prints timings to the job log
+        # for a human to eyeball across PRs rather than gating the build on them.
+        run: cargo bench --all-features
+        continue-on-error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ optional = true
 
 [dev-dependencies]
 async-trait = "^0.1"
+criterion = "^0.8"
 http = "^1.0"
 mockito = "^1.7.0"
 rdkafka = { version = "^0.39.0", features = ["cmake-build", "curl-static"] }
@@ -100,3 +101,27 @@ tokio = { version = "^1.46.1", features = ["macros"] }
 
 [package.metadata.docs.rs]
 all-features = true
+
+# Benchmarks of the blocking API's hot path (schema already cached), see
+# https://github.com/gklijs/schema_registry_converter/issues/118. Each one needs its matching
+# format feature plus `blocking`, so run e.g. `cargo bench --features avro,blocking` for a single
+# group, or `cargo bench --all-features` for all of them.
+[[bench]]
+name = "avro_bench"
+harness = false
+required-features = ["avro", "blocking"]
+
+[[bench]]
+name = "proto_raw_bench"
+harness = false
+required-features = ["proto_raw", "blocking"]
+
+[[bench]]
+name = "proto_decoder_bench"
+harness = false
+required-features = ["proto_decoder", "blocking"]
+
+[[bench]]
+name = "json_bench"
+harness = false
+required-features = ["json", "blocking"]

--- a/benches/avro_bench.rs
+++ b/benches/avro_bench.rs
@@ -1,0 +1,59 @@
+//! Benchmarks for the blocking Avro encoder/decoder, see
+//! https://github.com/gklijs/schema_registry_converter/issues/118.
+//!
+//! The schema registry lookup is mocked and done once before timing starts, so what's measured
+//! is the cache-hit hot path: avro (de)serialization, not network/mock overhead. That's the path
+//! that matters for a long-running consumer/producer once it has warmed up.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use schema_registry_converter::blocking::avro::{AvroDecoder, AvroEncoder};
+use schema_registry_converter::blocking::schema_registry::SrSettings;
+use schema_registry_converter::schema_registry_common::SubjectNameStrategy;
+use std::hint::black_box;
+use test_utils::Heartbeat;
+
+fn avro_benchmarks(c: &mut Criterion) {
+    let mut server = mockito::Server::new();
+    let _m = server
+        .mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
+        .with_status(200)
+        .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+        .with_body(r#"{"subject":"heartbeat-value","version":1,"id":4,"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
+        .create();
+    // The decoder caches by schema id and looks it up independently of the encoder's
+    // subject-based cache above, so it needs its own mock.
+    let _m2 = server
+        .mock("GET", "/schemas/ids/4?deleted=true")
+        .with_status(200)
+        .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+        .with_body(r#"{"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
+        .create();
+
+    let sr_settings = SrSettings::new_builder(server.url())
+        .no_proxy()
+        .build()
+        .unwrap();
+    let encoder = AvroEncoder::new(sr_settings.clone());
+    let strategy =
+        SubjectNameStrategy::RecordNameStrategy(String::from("nl.openweb.data.Heartbeat"));
+
+    // Warm the cache: the mock only ever answers once, everything timed below is served from it.
+    let encoded = encoder
+        .encode_struct(Heartbeat { beat: 3 }, &strategy)
+        .unwrap();
+
+    c.bench_function("avro_encode_struct_cached", |b| {
+        b.iter(|| encoder.encode_struct(black_box(Heartbeat { beat: 3 }), black_box(&strategy)))
+    });
+
+    let decoder = AvroDecoder::new(sr_settings);
+    // Warm the decoder's cache too, using the bytes the encoder above just produced.
+    decoder.decode(Some(&encoded)).unwrap();
+
+    c.bench_function("avro_decode_cached", |b| {
+        b.iter(|| decoder.decode(black_box(Some(&encoded))))
+    });
+}
+
+criterion_group!(benches, avro_benchmarks);
+criterion_main!(benches);

--- a/benches/json_bench.rs
+++ b/benches/json_bench.rs
@@ -1,0 +1,62 @@
+//! Benchmarks for the blocking JSON Schema encoder/decoder, see
+//! https://github.com/gklijs/schema_registry_converter/issues/118.
+//!
+//! As with the other benches here, the schema registry lookup is mocked and done once before
+//! timing starts, so this measures the cache-hit hot path: JSON Schema validation, not
+//! network/mock overhead.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use schema_registry_converter::blocking::json::{JsonDecoder, JsonEncoder};
+use schema_registry_converter::blocking::schema_registry::SrSettings;
+use schema_registry_converter::schema_registry_common::SubjectNameStrategy;
+use serde_json::json;
+use std::hint::black_box;
+use test_utils::{get_json_body, json_result_schema};
+
+fn json_benchmarks(c: &mut Criterion) {
+    let mut server = mockito::Server::new();
+    let _m = server
+        .mock("GET", "/subjects/testresult-value/versions/latest")
+        .with_status(200)
+        .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+        .with_body(get_json_body(json_result_schema(), 10))
+        .create();
+    // The decoder caches by schema id and looks it up independently of the encoder's
+    // subject-based cache above, so it needs its own mock.
+    let _m2 = server
+        .mock("GET", "/schemas/ids/10?deleted=true")
+        .with_status(200)
+        .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+        .with_body(get_json_body(json_result_schema(), 10))
+        .create();
+
+    let sr_settings = SrSettings::new_builder(server.url())
+        .no_proxy()
+        .build()
+        .unwrap();
+    let mut encoder = JsonEncoder::new(sr_settings.clone());
+    let strategy = SubjectNameStrategy::TopicNameStrategy(String::from("testresult"), false);
+    let value = json!({"up": "some", "down": "other"});
+
+    // Warm the cache: the mocks only ever answer once, everything timed below is served from it.
+    let encoded = encoder.encode(&value, &strategy).unwrap();
+
+    c.bench_function("json_encode_cached", |b| {
+        b.iter(|| encoder.encode(black_box(&value), black_box(&strategy)))
+    });
+
+    let mut decoder = JsonDecoder::new(sr_settings);
+    decoder.decode(Some(&encoded)).unwrap();
+
+    // Unlike the other decoders here, JsonDecoder::decode borrows from `&mut self` in its
+    // return type, which can't escape a `FnMut` closure, so the result is consumed (via
+    // black_box) inside the closure instead of being returned out of it.
+    c.bench_function("json_decode_cached", |b| {
+        b.iter(|| {
+            black_box(decoder.decode(black_box(Some(&encoded))).unwrap());
+        })
+    });
+}
+
+criterion_group!(benches, json_benchmarks);
+criterion_main!(benches);

--- a/benches/proto_decoder_bench.rs
+++ b/benches/proto_decoder_bench.rs
@@ -1,0 +1,38 @@
+//! Benchmark for the blocking `protofish`-backed `ProtoDecoder`, see
+//! https://github.com/gklijs/schema_registry_converter/issues/118.
+//!
+//! Kept separate from `proto_raw_bench`: `ProtoDecoder` fully parses the `.proto` schema and
+//! decodes the message through `protofish`, a materially heavier path than the raw decoder's
+//! index-based framing, so it's worth tracking on its own.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use schema_registry_converter::blocking::proto_decoder::ProtoDecoder;
+use schema_registry_converter::blocking::schema_registry::SrSettings;
+use std::hint::black_box;
+use test_utils::{get_proto_body, get_proto_hb_101, get_proto_hb_schema};
+
+fn proto_decoder_benchmarks(c: &mut Criterion) {
+    let mut server = mockito::Server::new();
+    let _m = server
+        .mock("GET", "/schemas/ids/7?deleted=true")
+        .with_status(200)
+        .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+        .with_body(get_proto_body(get_proto_hb_schema(), 7))
+        .create();
+
+    let sr_settings = SrSettings::new_builder(server.url())
+        .no_proxy()
+        .build()
+        .unwrap();
+    let decoder = ProtoDecoder::new(sr_settings);
+
+    // Warm the cache: the mock only ever answers once, everything timed below is served from it.
+    decoder.decode(Some(get_proto_hb_101())).unwrap();
+
+    c.bench_function("proto_decoder_decode_cached", |b| {
+        b.iter(|| decoder.decode(black_box(Some(get_proto_hb_101()))))
+    });
+}
+
+criterion_group!(benches, proto_decoder_benchmarks);
+criterion_main!(benches);

--- a/benches/proto_raw_bench.rs
+++ b/benches/proto_raw_bench.rs
@@ -1,0 +1,70 @@
+//! Benchmarks for the blocking raw protobuf encoder/decoder, see
+//! https://github.com/gklijs/schema_registry_converter/issues/118.
+//!
+//! As with the other benches here, the schema registry lookup is mocked and done once before
+//! timing starts, so this measures the cache-hit hot path (index resolving + framing), not
+//! network/mock overhead.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use schema_registry_converter::blocking::proto_raw::{ProtoRawDecoder, ProtoRawEncoder};
+use schema_registry_converter::blocking::schema_registry::SrSettings;
+use schema_registry_converter::schema_registry_common::SubjectNameStrategy;
+use std::hint::black_box;
+use test_utils::{
+    get_proto_body, get_proto_hb_101, get_proto_hb_101_only_data, get_proto_hb_schema,
+};
+
+fn proto_raw_benchmarks(c: &mut Criterion) {
+    let mut server = mockito::Server::new();
+    let _m = server
+        .mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
+        .with_status(200)
+        .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+        .with_body(get_proto_body(get_proto_hb_schema(), 7))
+        .create();
+    // The decoder caches by schema id and looks it up independently of the encoder's
+    // subject-based cache above, so it needs its own mock.
+    let _m2 = server
+        .mock("GET", "/schemas/ids/7?deleted=true")
+        .with_status(200)
+        .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+        .with_body(get_proto_body(get_proto_hb_schema(), 7))
+        .create();
+
+    let sr_settings = SrSettings::new_builder(server.url())
+        .no_proxy()
+        .build()
+        .unwrap();
+    let encoder = ProtoRawEncoder::new(sr_settings.clone());
+    let strategy =
+        SubjectNameStrategy::RecordNameStrategy(String::from("nl.openweb.data.Heartbeat"));
+
+    // Warm the cache: the mock only ever answers once, everything timed below is served from it.
+    encoder
+        .encode(
+            get_proto_hb_101_only_data(),
+            "nl.openweb.data.Heartbeat",
+            &strategy,
+        )
+        .unwrap();
+
+    c.bench_function("proto_raw_encode_cached", |b| {
+        b.iter(|| {
+            encoder.encode(
+                black_box(get_proto_hb_101_only_data()),
+                black_box("nl.openweb.data.Heartbeat"),
+                black_box(&strategy),
+            )
+        })
+    });
+
+    let decoder = ProtoRawDecoder::new(sr_settings);
+    decoder.decode(Some(get_proto_hb_101())).unwrap();
+
+    c.bench_function("proto_raw_decode_cached", |b| {
+        b.iter(|| decoder.decode(black_box(Some(get_proto_hb_101()))))
+    });
+}
+
+criterion_group!(benches, proto_raw_benchmarks);
+criterion_main!(benches);

--- a/scripts/bench_compare.py
+++ b/scripts/bench_compare.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Turns `cargo bench` output into a Markdown PR-comment comparing a PR build to main.
+
+See https://github.com/gklijs/schema_registry_converter/issues/118 for the benchmarks
+themselves, and .github/workflows/bench-compare.yml for how this is invoked in CI.
+
+Criterion's `--baseline <name>` comparison mode is the source of truth for the "did this
+regress" numbers, but it *panics* (aborting the whole bench binary, including benchmarks
+listed after the missing one) the first time it meets a benchmark with no saved baseline of
+that name -- which is guaranteed to happen for every benchmark on the PR that first adds
+benches, and for any later PR that adds a new benchmark function. So the CI workflow always
+also does one plain, comparison-free run on the PR code (which can't panic that way) to get a
+complete set of current timings, and a best-effort `--baseline main` run per bench binary to
+get change data for whichever benchmarks *do* have something to compare against on main. This
+script merges the two: every benchmark gets a row (from the plain run), and rows for
+benchmarks the comparison run actually got through get a change percentage and verdict too.
+
+Usage: bench_compare.py <plain_run_output> <compare_run_output> [<compare_run_output> ...]
+Prints a Markdown table to stdout.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class Reading:
+    name: str
+    time: str
+    change_pct: float | None = None
+    verdict: str | None = None
+
+
+def _normalize_sign(token: str) -> float:
+    # Criterion prints the Unicode minus sign (U+2212), not ASCII '-'.
+    return float(token.replace("−", "-").rstrip("%"))
+
+
+def _is_bare_name(line: str) -> bool:
+    s = line.strip()
+    return bool(s) and all(c.isalnum() or c == "_" for c in s)
+
+
+def parse(text: str) -> dict[str, Reading]:
+    """Parses one `cargo bench` run's stdout into {benchmark_name: Reading}.
+
+    Criterion's layout varies with name length: a short name shares its line with `time:`,
+    a long one gets pushed to a bare line of its own with `time:` indented below it.
+    """
+    readings: dict[str, Reading] = {}
+    lines = text.splitlines()
+    pending_name: str | None = None
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "time:" in line and "[" in line:
+            prefix, _, rest = line.partition("time:")
+            name = prefix.strip() or pending_name
+            pending_name = None
+            if name is None:
+                i += 1
+                continue
+            bracket = rest[rest.find("[") + 1 : rest.find("]")]
+            parts = bracket.split()
+            point_time = f"{parts[2]} {parts[3]}" if len(parts) >= 4 else bracket
+            reading = Reading(name=name, time=point_time)
+
+            # An immediately following `change: [...]` + verdict line is optional -- present
+            # only when this run was a `--baseline` comparison AND the benchmark existed on
+            # that baseline already.
+            if i + 1 < len(lines) and "change:" in lines[i + 1]:
+                change_line = lines[i + 1]
+                bracket2 = change_line[change_line.find("[") + 1 : change_line.find("]")]
+                change_parts = bracket2.split()
+                if len(change_parts) == 3:
+                    reading.change_pct = _normalize_sign(change_parts[1])
+                if i + 2 < len(lines):
+                    reading.verdict = lines[i + 2].strip()
+                i += 3
+            else:
+                i += 1
+            readings[name] = reading
+            continue
+
+        if _is_bare_name(line):
+            pending_name = line.strip()
+        i += 1
+
+    return readings
+
+
+def classify(change_pct: float | None) -> tuple[str, str]:
+    if change_pct is None:
+        return "🆕", "no baseline on `main` yet"
+    if change_pct >= 5:
+        return "🔴", f"{change_pct:+.2f}% slower"
+    if change_pct <= -5:
+        return "🟢", f"{change_pct:+.2f}% faster"
+    return "⚪", f"{change_pct:+.2f}% (within noise)"
+
+
+def render(plain: dict[str, Reading], compared: dict[str, Reading]) -> str:
+    if not plain:
+        return (
+            "_No benchmark results were parsed -- check the `benchmarks` job log, "
+            "the output format may have changed._"
+        )
+
+    rows = []
+    regressions = 0
+    improvements = 0
+    for name in sorted(plain):
+        change_pct = compared.get(name, Reading(name, "")).change_pct
+        icon, desc = classify(change_pct)
+        time = plain[name].time
+        rows.append(f"| `{name}` | {time} | {icon} {desc} |")
+        if change_pct is not None:
+            if change_pct >= 5:
+                regressions += 1
+            elif change_pct <= -5:
+                improvements += 1
+
+    lines = [
+        "| Benchmark | PR time | vs `main` |",
+        "|---|---|---|",
+        *rows,
+    ]
+    if regressions:
+        lines.append(f"\n⚠️ **{regressions} benchmark(s) regressed by 5% or more.**")
+    elif improvements:
+        lines.append(f"\n✅ {improvements} benchmark(s) improved by 5% or more, none regressed.")
+    else:
+        lines.append("\nNo benchmark changed by more than 5% (or is new, see 🆕 rows above).")
+    lines.append(
+        "\n<sub>Comparison uses criterion's own significance test; ±5% is treated as noise. "
+        "Numbers come from a shared GitHub Actions runner, so treat them as directional, not "
+        "authoritative -- see [issue #118](https://github.com/gklijs/schema_registry_converter/issues/118).</sub>"
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(1)
+
+    with open(sys.argv[1], encoding="utf-8", errors="replace") as f:
+        plain = parse(f.read())
+
+    compared: dict[str, Reading] = {}
+    for path in sys.argv[2:]:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            compared.update(parse(f.read()))
+
+    print(render(plain, compared))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_bench_pass.sh
+++ b/scripts/run_bench_pass.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Runs all `[[bench]]` binaries in one of three modes, for the bench-compare workflow (see
+# .github/workflows/bench-compare.yml and https://github.com/gklijs/schema_registry_converter/issues/118).
+#
+#   plain                    Runs each binary with no criterion baseline flags. Always succeeds
+#                             if the code builds -- used to get a complete, panic-proof set of
+#                             current timings regardless of what main looks like.
+#   save-baseline <name>     Runs each binary with `--save-baseline <name>`.
+#   compare <name> <out_dir> Runs each binary with `--baseline <name>`, tolerating criterion's
+#                             panic-on-missing-baseline (thrown the first time it hits a
+#                             benchmark that doesn't exist under that baseline yet -- expected
+#                             for any newly added benchmark). Writes each binary's output to
+#                             <out_dir>/compare_<binary>.txt; scripts/bench_compare.py is what
+#                             makes sense of a binary that panicked partway through.
+#
+# The bench list below has to be kept in sync with the `[[bench]]` entries in Cargo.toml by
+# hand -- there isn't a `cargo bench --list`-style machine-readable source for name+features.
+set -euo pipefail
+
+BENCHES=(
+  "avro_bench:avro,blocking"
+  "proto_raw_bench:proto_raw,blocking"
+  "proto_decoder_bench:proto_decoder,blocking"
+  "json_bench:json,blocking"
+)
+# Trimmed from criterion's defaults (100 samples / 5s+3s) to keep CI time reasonable while
+# still giving the significance test enough to work with.
+CRITERION_ARGS=(--sample-size 60 --measurement-time 3 --warm-up-time 2)
+
+mode="${1:?usage: $0 plain / save-baseline NAME / compare NAME OUT_DIR}"
+
+case "$mode" in
+  plain)
+    for entry in "${BENCHES[@]}"; do
+      bin="${entry%%:*}"
+      feat="${entry##*:}"
+      cargo bench --bench "$bin" --features "$feat" -- "${CRITERION_ARGS[@]}"
+    done
+    ;;
+  save-baseline)
+    name="${2:?save-baseline needs a baseline name}"
+    for entry in "${BENCHES[@]}"; do
+      bin="${entry%%:*}"
+      feat="${entry##*:}"
+      cargo bench --bench "$bin" --features "$feat" -- --save-baseline "$name" "${CRITERION_ARGS[@]}"
+    done
+    ;;
+  compare)
+    name="${2:?compare needs a baseline name}"
+    out_dir="${3:?compare needs an output directory}"
+    mkdir -p "$out_dir"
+    for entry in "${BENCHES[@]}"; do
+      bin="${entry%%:*}"
+      feat="${entry##*:}"
+      # `|| true`: a missing baseline makes criterion panic (exit 101) partway through the
+      # binary. That's expected for a new benchmark, not a real failure -- whatever it managed
+      # to print before panicking (comparisons for benchmarks that DO have a baseline) is still
+      # useful, so keep going rather than losing the rest of the matrix over one panic.
+      cargo bench --bench "$bin" --features "$feat" -- --baseline "$name" "${CRITERION_ARGS[@]}" \
+        >"$out_dir/compare_$bin.txt" 2>&1 || true
+    done
+    ;;
+  *)
+    echo "usage: $0 {plain|save-baseline <name>|compare <name> <out_dir>}" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
  Add criterion-based benchmarks covering the blocking API's cache-hit
  hot path for Avro, raw protobuf, protofish-backed protobuf, and JSON
  Schema encode/decode. Schema registry lookups are mocked and done
  once before timing starts, so what's measured is (de)serialization
  cost, not network overhead.

  Add a non-gating `benchmarks` CI step (continue-on-error) that prints
  results to the job log for manual comparison across PRs, per the
  issue's own scope — shared runners are too noisy for reliable
  pass/fail thresholds.

Fixes https://github.com/gklijs/schema_registry_converter/issues/118

If this changes behaviour described in `schema_registry_converter.allium`, please update the spec too (or note in the PR why it doesn't need it).
