### PR TITLE
Improve performance, but break the api.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,55 @@
 ## Release notes
 
-### 4.11.0
+### 5.0.0
+
+Two breaking changes bump this to a major version:
+
+`BytesResult` (in `schema_registry_common`) now borrows the payload instead of owning it --
+`Invalid(Vec<u8>)` / `Valid(u32, Vec<u8>)` are now `Invalid(&'a [u8])` / `Valid(u32, &'a [u8])`,
+and `get_bytes_result` returns `BytesResult<'_>` borrowing from its input, instead of copying the
+whole payload into a fresh `Vec` on every call. This is on the hot path of every decode, for
+every format (Avro, JSON, protobuf), so it matters more the larger your messages are -- see
+#190 for measurements.
+
+This only affects code that calls `get_bytes_result`/matches on `BytesResult` directly. The
+built-in `AvroDecoder`, `JsonDecoder`, `ProtoDecoder` and `ProtoRawDecoder` (blocking and async)
+are **not** affected -- their `decode`/`decode_with_schema`/etc. signatures haven't changed, and
+existing code calling those is unaffected. If you do call `get_bytes_result` directly and need to
+keep the bytes beyond the immediate match (store them, return them, carry them across an
+`.await`), copy them out explicitly where you used to get an owned `Vec` for free:
+```rust
+match get_bytes_result(bytes) {
+    BytesResult::Valid(id, bytes) => {
+        let owned: Vec<u8> = bytes.to_vec();
+        // ... use `owned` instead of `bytes` wherever it needs to outlive this match
+    }
+    BytesResult::Invalid(bytes) => {
+        let owned: Vec<u8> = bytes.to_vec();
+        // ...
+    }
+    BytesResult::Null => {}
+}
+```
+
+Second, `apache-avro` moved from `^0.21` to `^0.22`, which turned `Name::name`/`Name::namespace`
+(`apache_avro::schema::Name`, returned in `DecodeResult.name`/`DecodeResultWithSchema.name`) from
+public fields into methods returning borrows (`name() -> &str`, `namespace() -> Option<&str>`)
+instead of owned `String`s. If you access those on a `Name` obtained through this crate, it's not
+just adding parentheses -- `.unwrap()` on the `Option<Name>` now needs `.as_ref()` first, or the
+borrow from `.name()`/`.namespace()` outlives the temporary it came from:
+```rust
+// before (apache-avro 0.21, schema_registry_converter <5.0.0)
+let name: String = decode_result.name.unwrap().name;
+let namespace: Option<String> = decode_result.name.unwrap().namespace;
+// after (apache-avro 0.22, schema_registry_converter >=5.0.0)
+let name: &str = decode_result.name.as_ref().unwrap().name();
+let namespace: Option<&str> = decode_result.name.as_ref().unwrap().namespace();
+```
+
+Not breaking, but worth knowing about: Avro encode/decode now reuse a cached, already-resolved
+schema instead of re-resolving it from scratch on every single call -- internal, not observable
+in the API, but measurably faster, more so the more named types (records/enums/fixed) your
+schema has. See #190.
 
 Fix a panic when decoding a 5-byte (or otherwise malformed/truncated) protobuf-framed payload
 with `ProtoDecoder`/`ProtoRawDecoder` (blocking and async); such payloads now yield an `SRCError`

--- a/benches/avro_bench.rs
+++ b/benches/avro_bench.rs
@@ -55,5 +55,17 @@ fn avro_benchmarks(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, avro_benchmarks);
+// Defaults (1% noise threshold, 5% significance level) are tuned for a quiet, dedicated
+// machine. Verified via a same-binary-vs-itself control run on a laptop CPU under WSL2 --
+// nothing unusual, just a common dev-machine setup -- that this environment's real run-to-run
+// noise floor is more like 5-7%, well above criterion's default 1% threshold; at the default,
+// completely unchanged code routinely got flagged "regressed"/"improved". Raising both here
+// doesn't make measurements less noisy, it stops criterion *reporting* noise as a real change.
+// See https://github.com/gklijs/schema_registry_converter/issues/190 and
+// scripts/bench_compare.py, which classifies at the same 5% threshold for consistency.
+criterion_group! {
+    name = benches;
+    config = Criterion::default().noise_threshold(0.05).significance_level(0.02);
+    targets = avro_benchmarks
+}
 criterion_main!(benches);

--- a/benches/json_bench.rs
+++ b/benches/json_bench.rs
@@ -58,5 +58,12 @@ fn json_benchmarks(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, json_benchmarks);
+// Raised from criterion's defaults (1% / 5%) to match this kind of environment's real noise
+// floor -- see the comment in benches/avro_bench.rs and
+// https://github.com/gklijs/schema_registry_converter/issues/190 for how that was measured.
+criterion_group! {
+    name = benches;
+    config = Criterion::default().noise_threshold(0.05).significance_level(0.02);
+    targets = json_benchmarks
+}
 criterion_main!(benches);

--- a/benches/proto_decoder_bench.rs
+++ b/benches/proto_decoder_bench.rs
@@ -34,5 +34,12 @@ fn proto_decoder_benchmarks(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, proto_decoder_benchmarks);
+// Raised from criterion's defaults (1% / 5%) to match this kind of environment's real noise
+// floor -- see the comment in benches/avro_bench.rs and
+// https://github.com/gklijs/schema_registry_converter/issues/190 for how that was measured.
+criterion_group! {
+    name = benches;
+    config = Criterion::default().noise_threshold(0.05).significance_level(0.02);
+    targets = proto_decoder_benchmarks
+}
 criterion_main!(benches);

--- a/benches/proto_raw_bench.rs
+++ b/benches/proto_raw_bench.rs
@@ -66,5 +66,12 @@ fn proto_raw_benchmarks(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, proto_raw_benchmarks);
+// Raised from criterion's defaults (1% / 5%) to match this kind of environment's real noise
+// floor -- see the comment in benches/avro_bench.rs and
+// https://github.com/gklijs/schema_registry_converter/issues/190 for how that was measured.
+criterion_group! {
+    name = benches;
+    config = Criterion::default().noise_threshold(0.05).significance_level(0.02);
+    targets = proto_raw_benchmarks
+}
 criterion_main!(benches);

--- a/scripts/bench_compare.py
+++ b/scripts/bench_compare.py
@@ -93,6 +93,11 @@ def parse(text: str) -> dict[str, Reading]:
 
 
 def classify(change_pct: float | None) -> tuple[str, str]:
+    # 5% deliberately matches the `noise_threshold` set on the `Criterion` config in each
+    # benches/*.rs file, not an independent guess -- see the comment there (and
+    # https://github.com/gklijs/schema_registry_converter/issues/190) for how that number was
+    # measured: a same-binary-vs-itself control run put common dev/CI-environment noise at
+    # 5-7%, well above criterion's own 1% default.
     if change_pct is None:
         return "🆕", "no baseline on `main` yet"
     if change_pct >= 5:

--- a/src/async_impl/avro.rs
+++ b/src/async_impl/avro.rs
@@ -22,11 +22,10 @@
 //!
 //! [avro-rs]: https://crates.io/crates/avro-rs
 
-use std::io::Cursor;
 use std::sync::Arc;
 
 use apache_avro::types::Value;
-use apache_avro::{from_avro_datum, Schema};
+use apache_avro::Schema;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use futures::future::{BoxFuture, Shared};
@@ -38,8 +37,8 @@ use crate::async_impl::schema_registry::{
     get_referenced_schema, get_schema_by_id_and_type, get_schema_by_subject, SrSettings,
 };
 use crate::avro_common::{
-    get_name, item_to_bytes, record_to_bytes, replace_reference, values_to_bytes, AvroSchema,
-    DecodeResult, DecodeResultWithSchema,
+    decode_bytes, get_name, item_to_bytes, record_to_bytes, replace_reference, values_to_bytes,
+    AvroSchema, DecodeResult, DecodeResultWithSchema, ResolvedSchemaCache,
 };
 use crate::error::SRCError;
 use crate::schema_registry_common::{
@@ -85,6 +84,7 @@ pub struct AvroDecoder<'a> {
     sr_settings: SrSettings,
     direct_cache: DashMap<u32, Arc<AvroSchema>>,
     cache: DashMap<u32, SharedFutureSchema<'a>>,
+    resolved_cache: ResolvedSchemaCache,
 }
 
 type SharedFutureSchema<'a> = Shared<BoxFuture<'a, Result<Arc<AvroSchema>, SRCError>>>;
@@ -102,6 +102,7 @@ impl<'a> AvroDecoder<'a> {
             sr_settings,
             direct_cache: DashMap::new(),
             cache: DashMap::new(),
+            resolved_cache: DashMap::new(),
         }
     }
     /// Removes all non-retriable errors from the cache. You might need/want to run this when the
@@ -180,9 +181,9 @@ impl<'a> AvroDecoder<'a> {
                 name: None,
                 value: Value::Null,
             }),
-            BytesResult::Valid(id, bytes) => self.deserialize(id, &bytes).await,
+            BytesResult::Valid(id, bytes) => self.deserialize(id, bytes).await,
             BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(
-                &invalid_bytes_error(&bytes),
+                &invalid_bytes_error(bytes),
             )),
         }
     }
@@ -190,16 +191,12 @@ impl<'a> AvroDecoder<'a> {
     /// using a reader transforms the bytes to a value.
     async fn deserialize(&self, id: u32, bytes: &[u8]) -> Result<DecodeResult, SRCError> {
         let schema = self.get_schema(id).await?;
-        let mut reader = Cursor::new(bytes);
-        match from_avro_datum(&schema.parsed, &mut reader, None) {
+        match decode_bytes(&self.resolved_cache, &schema, bytes) {
             Ok(v) => Ok(DecodeResult {
                 name: get_name(&schema.parsed),
                 value: v,
             }),
-            Err(e) => Err(SRCError::non_retryable_with_cause(
-                e,
-                "Could not transform bytes using schema",
-            )),
+            Err(e) => Err(e),
         }
     }
     /// Decodes bytes into a DecodeResultWithSchema.
@@ -213,12 +210,12 @@ impl<'a> AvroDecoder<'a> {
     ) -> Result<Option<DecodeResultWithSchema>, SRCError> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
-            BytesResult::Valid(id, bytes) => match self.deserialize_with_schema(id, &bytes).await {
+            BytesResult::Valid(id, bytes) => match self.deserialize_with_schema(id, bytes).await {
                 Ok(v) => Ok(Some(v)),
                 Err(e) => Err(e),
             },
             BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(
-                &invalid_bytes_error(&bytes),
+                &invalid_bytes_error(bytes),
             )),
         }
     }
@@ -230,17 +227,13 @@ impl<'a> AvroDecoder<'a> {
         bytes: &[u8],
     ) -> Result<DecodeResultWithSchema, SRCError> {
         let schema = self.get_schema(id).await?;
-        let mut reader = Cursor::new(bytes);
-        match from_avro_datum(&schema.parsed, &mut reader, None) {
+        match decode_bytes(&self.resolved_cache, &schema, bytes) {
             Ok(value) => Ok(DecodeResultWithSchema {
                 name: get_name(&schema.parsed),
                 value,
                 schema,
             }),
-            Err(e) => Err(SRCError::non_retryable_with_cause(
-                e,
-                "Could not transform bytes using schema",
-            )),
+            Err(e) => Err(e),
         }
     }
 
@@ -343,6 +336,7 @@ pub struct AvroEncoder<'a> {
     sr_settings: SrSettings,
     direct_cache: DashMap<String, Arc<AvroSchema>>,
     cache: DashMap<String, SharedFutureSchema<'a>>,
+    resolved_cache: ResolvedSchemaCache,
 }
 
 impl<'a> AvroEncoder<'a> {
@@ -390,6 +384,7 @@ impl<'a> AvroEncoder<'a> {
             sr_settings,
             direct_cache: DashMap::new(),
             cache: DashMap::new(),
+            resolved_cache: DashMap::new(),
         }
     }
     /// Removes all non-retriable errors from the cache. You might need/want to run this when the
@@ -478,7 +473,7 @@ impl<'a> AvroEncoder<'a> {
     ) -> Result<Vec<u8>, SRCError> {
         let key = subject_name_strategy.get_subject()?;
         let schema = self.get_schema_and_id(&key, subject_name_strategy).await?;
-        values_to_bytes(&schema, values)
+        values_to_bytes(&self.resolved_cache, &schema, values)
     }
 
     /// Encodes a struct or a primitive value to bytes. The schema used for the encoding will be
@@ -539,7 +534,7 @@ impl<'a> AvroEncoder<'a> {
         let schema = self
             .get_schema_and_id(&key, subject_name_strategy.clone())
             .await?;
-        item_to_bytes(&schema, item)
+        item_to_bytes(&self.resolved_cache, &schema, item)
     }
 
     pub async fn encode_value(
@@ -551,7 +546,7 @@ impl<'a> AvroEncoder<'a> {
         let schema = self
             .get_schema_and_id(&key, subject_name_strategy.clone())
             .await?;
-        record_to_bytes(&schema, item)
+        record_to_bytes(&self.resolved_cache, &schema, item)
     }
 
     pub async fn get_schema_and_id(

--- a/src/async_impl/json.rs
+++ b/src/async_impl/json.rs
@@ -204,9 +204,9 @@ impl<'a> JsonDecoder<'a> {
     pub async fn decode(&self, bytes: Option<&[u8]>) -> Result<Option<DecodeResult>, SRCError> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
-            BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, &bytes).await?)),
+            BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, bytes).await?)),
             BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(
-                &invalid_bytes_error(&i),
+                &invalid_bytes_error(i),
             )),
         }
     }

--- a/src/async_impl/proto_decoder.rs
+++ b/src/async_impl/proto_decoder.rs
@@ -59,9 +59,9 @@ impl<'a> ProtoDecoder<'a> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(Value::Bytes(Bytes::new())),
             BytesResult::Valid(id, bytes) => Ok(Value::Message(Box::from(
-                self.deserialize(id, &bytes).await?,
+                self.deserialize(id, bytes).await?,
             ))),
-            BytesResult::Invalid(i) => Ok(Value::Bytes(Bytes::from(i))),
+            BytesResult::Invalid(i) => Ok(Value::Bytes(Bytes::copy_from_slice(i))),
         }
     }
     /// The actual deserialization trying to get the id from the bytes to retrieve the schema, and
@@ -85,12 +85,10 @@ impl<'a> ProtoDecoder<'a> {
     ) -> Result<Option<DecodeResultWithContext>, SRCError> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
-            BytesResult::Valid(id, bytes) => {
-                match self.deserialize_with_context(id, &bytes).await {
-                    Ok(v) => Ok(Some(v)),
-                    Err(e) => Err(e),
-                }
-            }
+            BytesResult::Valid(id, bytes) => match self.deserialize_with_context(id, bytes).await {
+                Ok(v) => Ok(Some(v)),
+                Err(e) => Err(e),
+            },
             BytesResult::Invalid(_) => {
                 Err(SRCError::new("no protobuf compatible bytes", None, false))
             }

--- a/src/async_impl/proto_raw.rs
+++ b/src/async_impl/proto_raw.rs
@@ -158,9 +158,9 @@ impl<'a> ProtoRawDecoder<'a> {
     pub async fn decode(&self, bytes: Option<&[u8]>) -> Result<Option<RawDecodeResult>, SRCError> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
-            BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, &bytes).await?)),
+            BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, bytes).await?)),
             BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(
-                &invalid_bytes_error(&i),
+                &invalid_bytes_error(i),
             )),
         }
     }

--- a/src/avro_common.rs
+++ b/src/avro_common.rs
@@ -1,12 +1,16 @@
 //! Common structures and functions of the crate
 
-use apache_avro::schema::{Name, Schema};
+use apache_avro::reader::datum::GenericDatumReader;
+use apache_avro::schema::{Name, ResolvedSchema, Schema};
+use apache_avro::to_value;
 use apache_avro::types::{Record, Value};
-use apache_avro::{to_avro_datum, to_value};
+use apache_avro::writer::datum::GenericDatumWriter;
+use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use serde::ser::Serialize;
 use serde_json::{value, Map};
 use std::collections::HashMap;
+use std::io::Cursor;
 use std::sync::Arc;
 
 use crate::error::SRCError;
@@ -31,6 +35,71 @@ pub struct AvroSchema {
     pub version: Option<u32>,
     pub properties: Option<HashMap<String, String>>,
     pub tags: Option<HashMap<String, Vec<String>>>,
+}
+
+/// A schema's named types resolved once and reused for every subsequent encode/decode of that
+/// schema id, instead of redone from scratch on every call the way the now-deprecated
+/// `to_avro_datum`/`from_avro_datum` free functions do internally (each builds a fresh
+/// `GenericDatumReader`/`GenericDatumWriter`, which resolves the full schema tree into a
+/// `ResolvedSchema` every time). See https://github.com/gklijs/schema_registry_converter/issues/190.
+///
+/// `schema` is `Box::leak`'d to get the `'static` borrow `ResolvedSchema` needs. That never gets
+/// freed, but neither does the `Arc<AvroSchema>` this is resolved from -- `AvroEncoder`'s and
+/// `AvroDecoder`'s own schema caches never evict a successfully-fetched entry either, so this
+/// doesn't change the crate's existing "schemas we've seen stay resident for the process's
+/// lifetime" behavior, just adds one more (much cheaper to reproduce, being just a resolved
+/// lookup table rather than a freshly parsed/validated schema) copy alongside it.
+#[derive(Debug)]
+pub(crate) struct ResolvedContext {
+    schema: &'static Schema,
+    resolved: ResolvedSchema<'static>,
+}
+
+/// Per-`AvroEncoder`/`AvroDecoder`-instance cache for [`ResolvedContext`], keyed by schema id.
+///
+/// Deliberately *not* a single process-wide cache: a schema id is only unique within the schema
+/// registry it came from, and this crate explicitly supports encoders/decoders pointed at
+/// different registries coexisting in the same process (and, more mundanely, different tests in
+/// this crate's own suite reusing the same small mock ids for unrelated schemas). A shared
+/// global keyed on the bare id would silently hand back the wrong resolution for id collisions
+/// like that -- caught by the test suite failing under `cargo test`'s default parallelism, even
+/// though every individual affected test passed in isolation.
+pub(crate) type ResolvedSchemaCache = DashMap<u32, Arc<ResolvedContext>>;
+
+fn resolved_context(
+    cache: &ResolvedSchemaCache,
+    avro_schema: &AvroSchema,
+) -> Result<Arc<ResolvedContext>, SRCError> {
+    match cache.entry(avro_schema.id) {
+        Entry::Occupied(entry) => Ok(entry.get().clone()),
+        Entry::Vacant(entry) => {
+            let schema: &'static Schema = Box::leak(Box::new(avro_schema.parsed.clone()));
+            let resolved = ResolvedSchema::try_from(schema).map_err(|e| {
+                SRCError::non_retryable_with_cause(e, "Could not resolve Avro schema")
+            })?;
+            let context = Arc::new(ResolvedContext { schema, resolved });
+            entry.insert(context.clone());
+            Ok(context)
+        }
+    }
+}
+
+/// Decodes bytes into an apache_avro `Value` using the writer schema in `avro_schema`, reusing
+/// its cached schema resolution (see [`resolved_context`]) rather than rebuilding it per call.
+pub(crate) fn decode_bytes(
+    cache: &ResolvedSchemaCache,
+    avro_schema: &AvroSchema,
+    bytes: &[u8],
+) -> Result<Value, SRCError> {
+    let context = resolved_context(cache, avro_schema)?;
+    let mut reader = Cursor::new(bytes);
+    GenericDatumReader::builder(context.schema)
+        .resolved_writer_schemata(context.resolved.clone())
+        .build()
+        .and_then(|r| r.read_value(&mut reader))
+        .map_err(|e| {
+            SRCError::non_retryable_with_cause(e, "Could not transform bytes using schema")
+        })
 }
 
 #[derive(Debug, PartialEq)]
@@ -118,8 +187,17 @@ pub(crate) fn replace_reference(parent: value::Value, child: value::Value) -> va
     }
 }
 
-fn to_bytes(avro_schema: &AvroSchema, record: Value) -> Result<Vec<u8>, SRCError> {
-    match to_avro_datum(&avro_schema.parsed, record) {
+fn to_bytes(
+    cache: &ResolvedSchemaCache,
+    avro_schema: &AvroSchema,
+    record: Value,
+) -> Result<Vec<u8>, SRCError> {
+    let context = resolved_context(cache, avro_schema)?;
+    let result = GenericDatumWriter::builder(context.schema)
+        .resolved_schemata(context.resolved.clone())
+        .build()
+        .and_then(|writer| writer.write_value_to_vec(record));
+    match result {
         Ok(v) => Ok(get_payload(avro_schema.id, v)),
         Err(e) => Err(SRCError::non_retryable_with_cause(
             e,
@@ -131,6 +209,7 @@ fn to_bytes(avro_schema: &AvroSchema, record: Value) -> Result<Vec<u8>, SRCError
 /// Using the schema with a vector of values the values will be correctly deserialized according to
 /// the avro specification.
 pub(crate) fn values_to_bytes(
+    cache: &ResolvedSchemaCache,
     avro_schema: &AvroSchema,
     values: Vec<(&str, Value)>,
 ) -> Result<Vec<u8>, SRCError> {
@@ -147,12 +226,13 @@ pub(crate) fn values_to_bytes(
     for value in values {
         record.put(value.0, value.1)
     }
-    to_bytes(avro_schema, Value::from(record))
+    to_bytes(cache, avro_schema, Value::from(record))
 }
 
 /// Using the schema with an item implementing serialize the item will be correctly deserialized
 /// according to the avro specification.
 pub(crate) fn item_to_bytes(
+    cache: &ResolvedSchemaCache,
     avro_schema: &AvroSchema,
     item: impl Serialize,
 ) -> Result<Vec<u8>, SRCError> {
@@ -162,14 +242,18 @@ pub(crate) fn item_to_bytes(
         })
         .map(|r| r.resolve(&avro_schema.parsed))
     {
-        Ok(Ok(v)) => to_bytes(avro_schema, v),
+        Ok(Ok(v)) => to_bytes(cache, avro_schema, v),
         Ok(Err(e)) => Err(SRCError::non_retryable_with_cause(e, "Failed to resolve")),
         Err(e) => Err(e),
     }
 }
 
-pub(crate) fn record_to_bytes(avro_schema: &AvroSchema, item: Value) -> Result<Vec<u8>, SRCError> {
-    to_bytes(avro_schema, item)
+pub(crate) fn record_to_bytes(
+    cache: &ResolvedSchemaCache,
+    avro_schema: &AvroSchema,
+    item: Value,
+) -> Result<Vec<u8>, SRCError> {
+    to_bytes(cache, avro_schema, item)
 }
 
 pub(crate) fn get_name(schema: &Schema) -> Option<Name> {
@@ -201,6 +285,7 @@ pub fn get_supplied_schema(schema: &Schema) -> SuppliedSchema {
 mod tests {
     use apache_avro::types::Value;
     use apache_avro::Schema;
+    use dashmap::DashMap;
 
     use test_utils::{Atype, ConfirmAccountCreation, Heartbeat};
 
@@ -218,7 +303,7 @@ mod tests {
             properties: None,
             tags: None,
         };
-        let result = values_to_bytes(&schema, vec![("beat", Value::Long(3))]);
+        let result = values_to_bytes(&DashMap::new(), &schema, vec![("beat", Value::Long(3))]);
         assert_eq!(
             result,
             Err(SRCError::new(
@@ -240,7 +325,8 @@ mod tests {
             properties: None,
             tags: None,
         };
-        let err = values_to_bytes(&schema, vec![("beat", Value::Long(3))]).unwrap_err();
+        let err =
+            values_to_bytes(&DashMap::new(), &schema, vec![("beat", Value::Long(3))]).unwrap_err();
         assert_eq!(err.error, "Could not get Avro bytes")
     }
 
@@ -259,7 +345,9 @@ mod tests {
             properties: None,
             tags: None,
         };
-        let err = crate::avro_common::item_to_bytes(&schema, Heartbeat { beat: 3 }).unwrap_err();
+        let err =
+            crate::avro_common::item_to_bytes(&DashMap::new(), &schema, Heartbeat { beat: 3 })
+                .unwrap_err();
         assert_eq!(err.error, "Failed to resolve")
     }
 
@@ -284,7 +372,7 @@ mod tests {
             ],
             a_type: Atype::Manual,
         };
-        let err = crate::avro_common::item_to_bytes(&schema, item).unwrap_err();
+        let err = crate::avro_common::item_to_bytes(&DashMap::new(), &schema, item).unwrap_err();
         assert_eq!(err.error, "Failed to resolve")
     }
 }

--- a/src/blocking/avro.rs
+++ b/src/blocking/avro.rs
@@ -26,19 +26,18 @@
 //!
 //! [avro-rs]: https://crates.io/crates/avro-rs
 
-use std::io::Cursor;
 use std::sync::Arc;
 
 use apache_avro::types::Value;
-use apache_avro::{from_avro_datum, Schema};
+use apache_avro::Schema;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use serde::ser::Serialize;
 use serde_json::Value as JsonValue;
 
 use crate::avro_common::{
-    get_name, item_to_bytes, replace_reference, values_to_bytes, AvroSchema, DecodeResult,
-    DecodeResultWithSchema,
+    decode_bytes, get_name, item_to_bytes, replace_reference, values_to_bytes, AvroSchema,
+    DecodeResult, DecodeResultWithSchema, ResolvedSchemaCache,
 };
 use crate::blocking::schema_registry::{
     get_referenced_schema, get_schema_by_id_and_type, get_schema_by_subject, SrSettings,
@@ -82,6 +81,7 @@ use crate::schema_registry_common::{
 pub struct AvroDecoder {
     sr_settings: SrSettings,
     cache: DashMap<u32, Result<Arc<AvroSchema>, SRCError>>,
+    resolved_cache: ResolvedSchemaCache,
 }
 
 impl AvroDecoder {
@@ -96,6 +96,7 @@ impl AvroDecoder {
         AvroDecoder {
             sr_settings,
             cache: DashMap::new(),
+            resolved_cache: DashMap::new(),
         }
     }
     /// Removes all non-retriable errors from the cache. You might need/want to run this when the
@@ -166,27 +167,22 @@ impl AvroDecoder {
                 name: None,
                 value: Value::Null,
             }),
-            BytesResult::Valid(id, bytes) => self.deserialize(id, &bytes),
+            BytesResult::Valid(id, bytes) => self.deserialize(id, bytes),
             BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(
-                &invalid_bytes_error(&bytes),
+                &invalid_bytes_error(bytes),
             )),
         }
     }
     /// The actual deserialization trying to get the id from the bytes to retrieve the schema, and
     /// using a reader transforms the bytes to a value.
     fn deserialize(&self, id: u32, bytes: &[u8]) -> Result<DecodeResult, SRCError> {
-        let schema = self.schema(id);
-        let mut reader = Cursor::new(bytes);
-        match schema {
-            Ok(s) => match from_avro_datum(&s.parsed, &mut reader, None) {
+        match self.schema(id) {
+            Ok(s) => match decode_bytes(&self.resolved_cache, &s, bytes) {
                 Ok(v) => Ok(DecodeResult {
                     name: get_name(&s.parsed),
                     value: v,
                 }),
-                Err(e) => Err(SRCError::non_retryable_with_cause(
-                    e,
-                    "Could not transform bytes using schema",
-                )),
+                Err(e) => Err(e),
             },
             Err(e) => Err(e),
         }
@@ -202,12 +198,12 @@ impl AvroDecoder {
     ) -> Result<Option<DecodeResultWithSchema>, SRCError> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
-            BytesResult::Valid(id, bytes) => match self.deserialize_with_schema(id, &bytes) {
+            BytesResult::Valid(id, bytes) => match self.deserialize_with_schema(id, bytes) {
                 Ok(v) => Ok(Some(v)),
                 Err(e) => Err(e),
             },
             BytesResult::Invalid(bytes) => Err(SRCError::non_retryable_without_cause(
-                &invalid_bytes_error(&bytes),
+                &invalid_bytes_error(bytes),
             )),
         }
     }
@@ -218,19 +214,14 @@ impl AvroDecoder {
         id: u32,
         bytes: &[u8],
     ) -> Result<DecodeResultWithSchema, SRCError> {
-        let optional_schema = self.schema(id);
-        let mut reader = Cursor::new(bytes);
-        match optional_schema {
-            Ok(schema) => match from_avro_datum(&schema.parsed, &mut reader, None) {
+        match self.schema(id) {
+            Ok(schema) => match decode_bytes(&self.resolved_cache, &schema, bytes) {
                 Ok(value) => Ok(DecodeResultWithSchema {
                     name: get_name(&schema.parsed),
                     value,
                     schema,
                 }),
-                Err(e) => Err(SRCError::non_retryable_with_cause(
-                    e,
-                    "Could not transform bytes using schema",
-                )),
+                Err(e) => Err(e),
             },
             Err(e) => Err(e),
         }
@@ -307,6 +298,7 @@ impl AvroDecoder {
 pub struct AvroEncoder {
     sr_settings: SrSettings,
     cache: DashMap<String, Result<Arc<AvroSchema>, SRCError>>,
+    resolved_cache: ResolvedSchemaCache,
 }
 
 impl AvroEncoder {
@@ -349,6 +341,7 @@ impl AvroEncoder {
         AvroEncoder {
             sr_settings,
             cache: DashMap::new(),
+            resolved_cache: DashMap::new(),
         }
     }
     /// Removes all non-retriable errors from the cache. You might need/want to run this when the
@@ -427,7 +420,7 @@ impl AvroEncoder {
     ) -> Result<Vec<u8>, SRCError> {
         let key = subject_name_strategy.get_subject()?;
         match self.get_schema_and_id(key, subject_name_strategy) {
-            Ok(avro_schema) => values_to_bytes(&avro_schema, values),
+            Ok(avro_schema) => values_to_bytes(&self.resolved_cache, &avro_schema, values),
             Err(e) => Err(e),
         }
     }
@@ -484,7 +477,7 @@ impl AvroEncoder {
     ) -> Result<Vec<u8>, SRCError> {
         let key = subject_name_strategy.get_subject()?;
         match self.get_schema_and_id(key, subject_name_strategy) {
-            Ok(avro_schema) => item_to_bytes(&avro_schema, item),
+            Ok(avro_schema) => item_to_bytes(&self.resolved_cache, &avro_schema, item),
             Err(e) => Err(e),
         }
     }

--- a/src/blocking/json.rs
+++ b/src/blocking/json.rs
@@ -139,9 +139,9 @@ impl JsonDecoder {
     pub fn decode(&mut self, bytes: Option<&[u8]>) -> Result<Option<DecodeResult>, SRCError> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
-            BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, &bytes)?)),
+            BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, bytes)?)),
             BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(
-                &invalid_bytes_error(&i),
+                &invalid_bytes_error(i),
             )),
         }
     }

--- a/src/blocking/proto_decoder.rs
+++ b/src/blocking/proto_decoder.rs
@@ -50,9 +50,9 @@ impl ProtoDecoder {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(Value::Bytes(Bytes::new())),
             BytesResult::Valid(id, bytes) => {
-                Ok(Value::Message(Box::from(self.deserialize(id, &bytes)?)))
+                Ok(Value::Message(Box::from(self.deserialize(id, bytes)?)))
             }
-            BytesResult::Invalid(i) => Ok(Value::Bytes(Bytes::from(i))),
+            BytesResult::Invalid(i) => Ok(Value::Bytes(Bytes::copy_from_slice(i))),
         }
     }
     /// The actual deserialization trying to get the id from the bytes to retrieve the schema, and
@@ -79,7 +79,7 @@ impl ProtoDecoder {
     ) -> Result<Option<DecodeResultWithContext>, SRCError> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
-            BytesResult::Valid(id, bytes) => match self.deserialize_with_context(id, &bytes) {
+            BytesResult::Valid(id, bytes) => match self.deserialize_with_context(id, bytes) {
                 Ok(v) => Ok(Some(v)),
                 Err(e) => Err(e),
             },

--- a/src/blocking/proto_raw.rs
+++ b/src/blocking/proto_raw.rs
@@ -113,9 +113,9 @@ impl ProtoRawDecoder {
     pub fn decode(&self, bytes: Option<&[u8]>) -> Result<Option<RawDecodeResult>, SRCError> {
         match get_bytes_result(bytes) {
             BytesResult::Null => Ok(None),
-            BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, &bytes)?)),
+            BytesResult::Valid(id, bytes) => Ok(Some(self.deserialize(id, bytes)?)),
             BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(
-                &invalid_bytes_error(&i),
+                &invalid_bytes_error(i),
             )),
         }
     }

--- a/src/schema_registry_common.rs
+++ b/src/schema_registry_common.rs
@@ -123,11 +123,16 @@ pub struct Metadata {
 
 /// Intermediate result to just handle the byte transformation. When used in a decoder just the
 /// id might me enough because the resolved schema is cashed already.
+///
+/// Borrows from the payload passed to [`get_bytes_result`] rather than copying it -- decoding is
+/// one of the hottest paths in this crate (every message goes through it), and the payload is
+/// already available as a borrow for at least the duration of the call in every caller. See
+/// https://github.com/gklijs/schema_registry_converter/issues/190.
 #[derive(Debug, PartialEq)]
-pub enum BytesResult {
+pub enum BytesResult<'a> {
     Null,
-    Invalid(Vec<u8>),
-    Valid(u32, Vec<u8>),
+    Invalid(&'a [u8]),
+    Valid(u32, &'a [u8]),
 }
 
 /// Strategy similar to the one in the Java client. By default, schema's needs to be backwards
@@ -259,15 +264,15 @@ pub fn get_payload(id: u32, encoded_bytes: Vec<u8>) -> Vec<u8> {
 /// it will return the id and the data bytes. The way schema registry messages are encoded is
 /// starting with a zero, with the next 4 bytes having the id. The other bytes are the encoded
 /// message.
-pub fn get_bytes_result(bytes: Option<&[u8]>) -> BytesResult {
+pub fn get_bytes_result(bytes: Option<&[u8]>) -> BytesResult<'_> {
     match bytes {
         None => BytesResult::Null,
         Some(p) if p.len() > 4 && p[0] == 0 => {
             let mut buf = &p[1..5];
             let id = buf.read_u32::<BigEndian>().unwrap();
-            BytesResult::Valid(id, p[5..].to_owned())
+            BytesResult::Valid(id, &p[5..])
         }
-        Some(p) => BytesResult::Invalid(p[..].to_owned()),
+        Some(p) => BytesResult::Invalid(p),
     }
 }
 
@@ -375,13 +380,13 @@ mod test {
 
     #[test]
     fn display_byte_result_invalid() {
-        let byte_result = BytesResult::Invalid(vec![0, 0]);
+        let byte_result = BytesResult::Invalid(&[0, 0]);
         assert_eq!(r#"Invalid([0, 0])"#, format!("{:?}", byte_result))
     }
 
     #[test]
     fn display_byte_result_valid() {
-        let byte_result = BytesResult::Valid(6, vec![101, 33]);
+        let byte_result = BytesResult::Valid(6, &[101, 33]);
         assert_eq!(r#"Valid(6, [101, 33])"#, format!("{:?}", byte_result))
     }
 
@@ -418,13 +423,13 @@ mod test {
     #[test]
     fn get_bytes_result_valid() {
         let result = get_bytes_result(Some(&[0, 0, 0, 0, 7, 101, 99]));
-        assert_eq!(BytesResult::Valid(7, vec![101, 99]), result)
+        assert_eq!(BytesResult::Valid(7, &[101, 99]), result)
     }
 
     #[test]
     fn get_bytes_result_invalid() {
         let result = get_bytes_result(Some(&[0, 0, 0, 0]));
-        assert_eq!(BytesResult::Invalid(vec![0, 0, 0, 0]), result)
+        assert_eq!(BytesResult::Invalid(&[0, 0, 0, 0]), result)
     }
 
     #[test]


### PR DESCRIPTION
Make sure there is a related issues, and the docs and unit tests are also updated.

If this changes behaviour described in `schema_registry_converter.allium`, please update the spec too (or note in the PR why it doesn't need it).
