### PR TITLE
Add support for schema id in Kafka headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,33 @@ fn get_future_record_from_struct<'a>(
 }
 ```
 
+## Schema id in Kafka headers
+
+Confluent Schema Registry 8.0 introduced an alternative wire format where the schema
+id/guid travels in a `__key_schema_id`/`__value_schema_id` Kafka header instead of being
+prefixed onto the payload, mirroring the Java client's `HeaderSchemaIdSerializer` /
+`DualSchemaIdDeserializer`. This crate has no dependency on any particular Kafka client, so
+[`SchemaIdHeader`](https://docs.rs/schema_registry_converter/latest/schema_registry_converter/schema_registry_common/struct.SchemaIdHeader.html)
+is plain data (a header `name` and `value`); attach it to the record using whatever
+`Headers`/`OwnedHeaders`/etc. type your Kafka client uses.
+
+Every encoder/decoder (Avro, JSON, protobuf; blocking and async) has `_with_header_id`
+variants alongside the regular ones:
+
+* `encode_with_header_id` (and, for Avro, `encode_struct_with_header_id` /
+  `encode_value_with_header_id`) return `(payload, SchemaIdHeader)` -- the payload has no
+  magic-byte/id prefix, and the header carries the schema's guid instead. This requires
+  Confluent Schema Registry 8.0+, since guids are what makes the format unambiguous without a
+  payload prefix.
+* `decode_with_header_id` takes the raw header bytes alongside the payload: pass `Some(header)`
+  to resolve the schema from the header and treat the payload as unprefixed, or `None` to fall
+  straight through to the regular `decode`, so a consumer that needs to handle both wire formats
+  (e.g. during a migration) can call it unconditionally.
+
+See [issue #139](https://github.com/gklijs/schema_registry_converter/issues/139) for background,
+and the docs on `decode_with_header_id`/`encode_with_header_id` for each converter for worked
+examples.
+
 ## Direct interaction with schema registry
 
 Some functions have been opened so this library can be used to directly get all the subjects, all the version of a

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -67,10 +67,12 @@ Add support for carrying the schema id/guid in a Kafka header instead of prefixi
 matching Confluent Schema Registry 8.0's `HeaderSchemaIdSerializer`/`DualSchemaIdDeserializer`.
 Every encoder/decoder (Avro, JSON, protobuf; blocking and async) gains `_with_header_id`
 variants, plain-data types `SchemaIdHeader`/`KEY_SCHEMA_ID_HEADER`/`VALUE_SCHEMA_ID_HEADER` are
-added to `schema_registry_common`, `RegisteredSchema`/`RawRegisteredSchema` gain a `guid` field,
-and schema lookup by guid (`GET /schemas/guids/{guid}`) is now supported alongside lookup by id.
-This is purely additive -- no existing signatures change. See #139 and the "Schema id in Kafka
-headers" section of the README.
+added to `schema_registry_common`, and schema lookup by guid (`GET /schemas/guids/{guid}`) is
+now supported alongside lookup by id. No existing function/method signature changes, so this is
+additive for all normal usage -- but `RegisteredSchema`, `RawRegisteredSchema`, `AvroSchema`, and
+`JsonSchema` all gain a new public `guid` field, which *is* a breaking change if you construct
+one of those via struct-literal syntax, or destructure one exhaustively without `..`. See #139
+and the "Schema id in Kafka headers" section of the README.
 
 ### 4.10.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -63,6 +63,15 @@ index bookkeeping from the real message nesting, since its lexer didn't previous
 string literals and treated every `{`/`}` as message nesting. String literals are now skipped as
 a whole when scanning for braces.
 
+Add support for carrying the schema id/guid in a Kafka header instead of prefixing the payload,
+matching Confluent Schema Registry 8.0's `HeaderSchemaIdSerializer`/`DualSchemaIdDeserializer`.
+Every encoder/decoder (Avro, JSON, protobuf; blocking and async) gains `_with_header_id`
+variants, plain-data types `SchemaIdHeader`/`KEY_SCHEMA_ID_HEADER`/`VALUE_SCHEMA_ID_HEADER` are
+added to `schema_registry_common`, `RegisteredSchema`/`RawRegisteredSchema` gain a `guid` field,
+and schema lookup by guid (`GET /schemas/guids/{guid}`) is now supported alongside lookup by id.
+This is purely additive -- no existing signatures change. See #139 and the "Schema id in Kafka
+headers" section of the README.
+
 ### 4.10.0
 
 Propagate properties and tags.

--- a/check_test_app_done.sh
+++ b/check_test_app_done.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-for i in $(seq 1 40); do
+# 100 * 3s = 5 minutes. Bumped from 40 (2 minutes) when the broker/schema-registry moved to
+# Confluent Platform 8.3.1 in KRaft (combined broker+controller) mode -- first boot has to format
+# the KRaft log dir and start Confluent Balancer/Metrics Reporter on top of that, which can take
+# noticeably longer than the old zookeeper-backed setup, especially on a shared CI runner.
+for i in $(seq 1 100); do
   running=$(docker inspect -f '{{ .State.Running }}' test-app)
   exit_code=$(docker inspect -f '{{ .State.ExitCode }}' test-app)
   # A freshly started container also reports ExitCode 0 (its unset default)
@@ -11,6 +15,17 @@ for i in $(seq 1 40); do
     echo -e "Successful load java data in loop ${i}"
     exit 0
   fi
+  # Fail fast on a genuine crash rather than waiting out the full timeout -- a non-zero exit
+  # here never turns into a 0 on a later loop -- and dump the logs while they're still around.
+  if [[ "$running" == "false" && "$exit_code" != "0" ]]; then
+    echo "test-app exited with code ${exit_code} after loop ${i}, logs:"
+    docker logs test-app
+    exit 1
+  fi
   sleep 3
 done
+echo "test-app still running after $((100 * 3))s, giving up. Logs from test-app/schema-registry/broker:"
+docker logs test-app
+docker logs schema-registry
+docker logs broker
 exit 1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,13 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
+      # Without this, Cluster Linking's internal _confluent-link-metadata topic is (re)created
+      # with a hardcoded replicationFactor=3 -- unlike the topics above, it has no single-broker
+      # fallback, so it fails with INVALID_REPLICATION_FACTOR and retries in a loop indefinitely,
+      # every ~30s for as long as the cluster runs. See
+      # https://github.com/confluentinc/cp-all-in-one/issues/139 (unresolved upstream as of
+      # Confluent Platform 8.3.1).
+      KAFKA_CONFLUENT_CLUSTER_LINK_METADATA_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,46 +1,45 @@
 ---
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.2.1
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
+  # Single-node broker+controller in KRaft (combined) mode. Confluent Platform 8.x no longer
+  # publishes cp-zookeeper images -- ZooKeeper mode is gone -- so this replaces the old
+  # zookeeper+broker pair. Config follows Confluent's own single-node KRaft example:
+  # https://github.com/confluentinc/cp-all-in-one/blob/8.2.0-post/cp-all-in-one/docker-compose.yml
   broker:
-    image: confluentinc/cp-server:7.2.1
+    image: confluentinc/cp-server:8.3.1
     hostname: broker
     container_name: broker
-    depends_on:
-      - zookeeper
     ports:
       - "9092:9092"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_LISTENERS: 'PLAINTEXT://broker:29092,CONTROLLER://broker:29093,PLAINTEXT_HOST://0.0.0.0:9092'
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@broker:29093'
+      KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+      # A fixed value is fine for a throwaway single-node dev cluster; a real deployment should
+      # generate its own with `kafka-storage.sh random-uuid`.
+      CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
       KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
-      CONFLUENT_METRICS_REPORTER_ZOOKEEPER_CONNECT: zookeeper:2181
       CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
       CONFLUENT_METRICS_ENABLE: 'true'
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.2.1
+    image: confluentinc/cp-schema-registry:8.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
-      - zookeeper
       - broker
     ports:
       - "8081:8081"
@@ -49,14 +48,16 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:29092'
 
   it-test-java-app:
+    # See https://github.com/gklijs/schema_registry_test_app. Produces to testavro/testjson/
+    # testproto/testgoogle as before, plus testavroheader/testjsonheader/testprotoheader (schema
+    # guid in a __value_schema_id header instead of the payload prefix) -- see
+    # https://github.com/gklijs/schema_registry_converter/issues/139.
     image: gklijs/schema-registry-test-app:latest
     container_name: test-app
     environment:
       SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
       BOOTSTRAP_SERVERS: 'broker:29092'
     depends_on:
-      - zookeeper
       - broker
       - schema-registry
     restart: on-failure
-

--- a/src/async_impl/avro.rs
+++ b/src/async_impl/avro.rs
@@ -44,9 +44,9 @@ use crate::avro_common::{
 };
 use crate::error::SRCError;
 use crate::schema_registry_common::{
-    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    get_bytes_result, invalid_bytes_error, parse_schema_id_header, schema_id_header_for,
     BytesResult, HeaderSchemaId, RegisteredReference, RegisteredSchema, SchemaIdHeader, SchemaType,
-    SubjectNameStrategy, KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
+    SubjectNameStrategy,
 };
 
 /// A decoder used to transform bytes to a Value object
@@ -229,7 +229,7 @@ impl<'a> AvroDecoder<'a> {
     /// # async fn doc() -> Result<(), reqwest::Error> {
     /// let mut server = Server::new_async().await;
     /// // GET /schemas/guids/{guid} never carries an "id" field on a real registry -- only "guid".
-    /// let _m = server .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+    /// let _m = server .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001?deleted=true")
     ///     .with_status(200)
     ///     .with_header("content-type", "application/vnd.schemaregistry.v1+json")
     ///     .with_body(r#"{"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
@@ -643,7 +643,7 @@ impl<'a> AvroEncoder<'a> {
         let key = subject_name_strategy.get_subject()?;
         let schema = self.get_schema_and_id(&key, subject_name_strategy).await?;
         let bytes = values_to_bytes_raw(&self.resolved_cache, &schema, values)?;
-        let header = schema_id_header_for(&schema, is_key)?;
+        let header = schema_id_header_for(schema.guid.as_deref(), is_key, &[])?;
         Ok((bytes, header))
     }
 
@@ -721,7 +721,7 @@ impl<'a> AvroEncoder<'a> {
             .get_schema_and_id(&key, subject_name_strategy.clone())
             .await?;
         let bytes = item_to_bytes_raw(&self.resolved_cache, &schema, item)?;
-        let header = schema_id_header_for(&schema, is_key)?;
+        let header = schema_id_header_for(schema.guid.as_deref(), is_key, &[])?;
         Ok((bytes, header))
     }
 
@@ -750,7 +750,7 @@ impl<'a> AvroEncoder<'a> {
             .get_schema_and_id(&key, subject_name_strategy.clone())
             .await?;
         let bytes = record_to_bytes_raw(&self.resolved_cache, &schema, item)?;
-        let header = schema_id_header_for(&schema, is_key)?;
+        let header = schema_id_header_for(schema.guid.as_deref(), is_key, &[])?;
         Ok((bytes, header))
     }
 
@@ -809,24 +809,6 @@ impl<'a> AvroEncoder<'a> {
             }
         }
     }
-}
-
-/// Builds the [`SchemaIdHeader`] for `schema`, requiring it to carry a guid (populated when the
-/// schema registry response included one, i.e. Confluent Schema Registry 8.0+). Avro has no
-/// message index, unlike protobuf, so there are no trailing bytes to append.
-fn schema_id_header_for(schema: &AvroSchema, is_key: bool) -> Result<SchemaIdHeader, SRCError> {
-    let guid = schema.guid.as_deref().ok_or_else(|| {
-        SRCError::non_retryable_without_cause(
-            "Schema registry response did not include a guid; encoding the schema id in a \
-             header requires Confluent Schema Registry 8.0+",
-        )
-    })?;
-    let name = if is_key {
-        KEY_SCHEMA_ID_HEADER
-    } else {
-        VALUE_SCHEMA_ID_HEADER
-    };
-    build_schema_id_header(name, guid, &[])
 }
 
 async fn to_avro_schema(

--- a/src/async_impl/avro.rs
+++ b/src/async_impl/avro.rs
@@ -34,16 +34,19 @@ use serde::ser::Serialize;
 use serde_json::value;
 
 use crate::async_impl::schema_registry::{
-    get_referenced_schema, get_schema_by_id_and_type, get_schema_by_subject, SrSettings,
+    get_referenced_schema, get_schema_by_guid_and_type, get_schema_by_id_and_type,
+    get_schema_by_subject, SrSettings,
 };
 use crate::avro_common::{
-    decode_bytes, get_name, item_to_bytes, record_to_bytes, replace_reference, values_to_bytes,
-    AvroSchema, DecodeResult, DecodeResultWithSchema, ResolvedSchemaCache,
+    decode_bytes, get_name, item_to_bytes, item_to_bytes_raw, record_to_bytes, record_to_bytes_raw,
+    replace_reference, values_to_bytes, values_to_bytes_raw, AvroSchema, DecodeResult,
+    DecodeResultWithSchema, ResolvedSchemaCache,
 };
 use crate::error::SRCError;
 use crate::schema_registry_common::{
-    get_bytes_result, invalid_bytes_error, BytesResult, RegisteredReference, RegisteredSchema,
-    SchemaType, SubjectNameStrategy,
+    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    BytesResult, HeaderSchemaId, RegisteredReference, RegisteredSchema, SchemaIdHeader, SchemaType,
+    SubjectNameStrategy, KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
 };
 
 /// A decoder used to transform bytes to a Value object
@@ -84,6 +87,11 @@ pub struct AvroDecoder<'a> {
     sr_settings: SrSettings,
     direct_cache: DashMap<u32, Arc<AvroSchema>>,
     cache: DashMap<u32, SharedFutureSchema<'a>>,
+    /// Cache for schemas looked up by guid rather than id, used by
+    /// [`AvroDecoder::decode_with_header_id`]. Kept separate from `direct_cache`/`cache` (keyed
+    /// by id) since a guid and an id are different keyspaces.
+    guid_direct_cache: DashMap<String, Arc<AvroSchema>>,
+    guid_cache: DashMap<String, SharedFutureSchema<'a>>,
     resolved_cache: ResolvedSchemaCache,
 }
 
@@ -102,6 +110,8 @@ impl<'a> AvroDecoder<'a> {
             sr_settings,
             direct_cache: DashMap::new(),
             cache: DashMap::new(),
+            guid_direct_cache: DashMap::new(),
+            guid_cache: DashMap::new(),
             resolved_cache: DashMap::new(),
         }
     }
@@ -154,6 +164,10 @@ impl<'a> AvroDecoder<'a> {
             Some(r) => r.is_ok(),
             None => true,
         });
+        self.guid_cache.retain(|_, v| match v.peek() {
+            Some(r) => r.is_ok(),
+            None => true,
+        });
     }
     /// Decodes bytes into a value.
     /// The choice to use Option<&[u8]> as type us made so it plays nice with the BorrowedMessage
@@ -197,6 +211,68 @@ impl<'a> AvroDecoder<'a> {
                 value: v,
             }),
             Err(e) => Err(e),
+        }
+    }
+    /// Like [`AvroDecoder::decode`], but for a message that may carry its schema id/guid in a
+    /// `__key_schema_id`/`__value_schema_id` header instead of (or in addition to) the payload
+    /// prefix, mirroring Confluent's `DualSchemaIdDeserializer`: `header_value` present ->
+    /// resolve the schema from it and treat `bytes` as the raw (unprefixed) payload;
+    /// `header_value` absent -> falls straight through to [`AvroDecoder::decode`], so the only
+    /// overhead for a caller who always passes `None` is this one check. See
+    /// https://github.com/gklijs/schema_registry_converter/issues/139.
+    /// ```
+    /// use apache_avro::types::Value;
+    /// use mockito::Server;
+    /// use schema_registry_converter::async_impl::avro::AvroDecoder;
+    /// use schema_registry_converter::async_impl::schema_registry::SrSettings;
+    ///
+    /// # async fn doc() -> Result<(), reqwest::Error> {
+    /// let mut server = Server::new_async().await;
+    /// let _m = server .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+    ///     .with_status(200)
+    ///     .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+    ///     .with_body(r#"{"id":1,"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
+    ///     .create();
+    ///
+    /// let sr_settings = SrSettings::new_builder(server.url()).no_proxy().build().unwrap();
+    /// let decoder = AvroDecoder::new(sr_settings);
+    /// let header_value = [0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
+    /// let heartbeat = decoder.decode_with_header_id(Some(&header_value), Some(&[6])).await.unwrap().value;
+    ///
+    /// assert_eq!(heartbeat, Value::Record(vec![("beat".to_string(), Value::Long(3))]));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn decode_with_header_id(
+        &self,
+        header_value: Option<&[u8]>,
+        bytes: Option<&[u8]>,
+    ) -> Result<DecodeResult, SRCError> {
+        let payload = match bytes {
+            Some(v) => v,
+            None => {
+                return Ok(DecodeResult {
+                    name: None,
+                    value: Value::Null,
+                });
+            }
+        };
+        match header_value {
+            None => self.decode(Some(payload)).await,
+            Some(header) => {
+                let (schema_id, _rest) = parse_schema_id_header(header)?;
+                let schema = match schema_id {
+                    HeaderSchemaId::Id(id) => self.get_schema(id).await?,
+                    HeaderSchemaId::Guid(guid) => self.get_schema_by_guid(guid).await?,
+                };
+                match decode_bytes(&self.resolved_cache, &schema, payload) {
+                    Ok(v) => Ok(DecodeResult {
+                        name: get_name(&schema.parsed),
+                        value: v,
+                    }),
+                    Err(e) => Err(e),
+                }
+            }
         }
     }
     /// Decodes bytes into a DecodeResultWithSchema.
@@ -270,6 +346,51 @@ impl<'a> AvroDecoder<'a> {
                 let sr_settings = self.sr_settings.clone();
                 let v = async move {
                     match get_schema_by_id_and_type(id, &sr_settings, SchemaType::Avro).await {
+                        Ok(registered_schema) => {
+                            to_avro_schema(&sr_settings, registered_schema).await
+                        }
+                        Err(e) => Err(e),
+                    }
+                }
+                .boxed()
+                .shared();
+                e.insert(v).value().clone()
+            }
+        }
+    }
+
+    /// Like [`AvroDecoder::get_schema`], but looks the schema up by guid instead of id -- used by
+    /// [`AvroDecoder::decode_with_header_id`] when the header carries a guid rather than an id.
+    async fn get_schema_by_guid(&self, guid: String) -> Result<Arc<AvroSchema>, SRCError> {
+        match self.guid_direct_cache.get(&guid) {
+            None => {
+                let result = self.get_schema_by_guid_shared_future(guid.clone()).await;
+                match result {
+                    Ok(v) => {
+                        if !self.guid_direct_cache.contains_key(&guid) {
+                            self.guid_direct_cache.insert(guid.clone(), v.clone());
+                            self.guid_cache.remove(&guid);
+                        }
+                        Ok(v)
+                    }
+                    Err(e) if e.retriable => {
+                        self.guid_cache.remove(&guid);
+                        Err(e)
+                    }
+                    Err(e) => Err(e.into_cache()),
+                }
+            }
+            Some(result) => Ok(result.value().clone()),
+        }
+    }
+
+    fn get_schema_by_guid_shared_future(&self, guid: String) -> SharedFutureSchema<'a> {
+        match self.guid_cache.entry(guid.clone()) {
+            Entry::Occupied(e) => e.get().clone(),
+            Entry::Vacant(e) => {
+                let sr_settings = self.sr_settings.clone();
+                let v = async move {
+                    match get_schema_by_guid_and_type(&guid, &sr_settings, SchemaType::Avro).await {
                         Ok(registered_schema) => {
                             to_avro_schema(&sr_settings, registered_schema).await
                         }
@@ -476,6 +597,55 @@ impl<'a> AvroEncoder<'a> {
         values_to_bytes(&self.resolved_cache, &schema, values)
     }
 
+    /// Like [`AvroEncoder::encode`], but instead of prefixing the payload with the schema id
+    /// (the default confluent wire format), returns the raw Avro bytes alongside a
+    /// [`SchemaIdHeader`] carrying the schema's guid. Attach the header to the Kafka record
+    /// using whatever Kafka client you're using -- this crate has no dependency on one. `is_key`
+    /// picks between the `__key_schema_id`/`__value_schema_id` header names, matching
+    /// Confluent's `HeaderSchemaIdSerializer`. See
+    /// https://github.com/gklijs/schema_registry_converter/issues/139.
+    ///
+    /// Requires a schema registry that returns a `guid` (Confluent Schema Registry 8.0+); a
+    /// registry that doesn't will make this return an error.
+    /// ```
+    /// use apache_avro::types::Value;
+    /// use mockito::Server;
+    /// use schema_registry_converter::async_impl::avro::AvroEncoder;
+    /// use schema_registry_converter::schema_registry_common::{SubjectNameStrategy, VALUE_SCHEMA_ID_HEADER};
+    /// use schema_registry_converter::async_impl::schema_registry::SrSettings;
+    ///
+    /// # async fn doc() -> Result<(), reqwest::Error> {
+    /// let mut server = Server::new_async().await;
+    /// let _m = server .mock("GET", "/subjects/heartbeat-nl.openweb.data.Heartbeat/versions/latest")
+    ///     .with_status(200)
+    ///     .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+    ///     .with_body(r#"{"subject":"heartbeat-value","version":1,"id":3,"guid":"cc0e0e0e-53c1-4a1a-8f1a-000000000001","schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
+    ///     .create();
+    ///
+    /// let sr_settings = SrSettings::new_builder(server.url()).no_proxy().build().unwrap();
+    /// let encoder = AvroEncoder::new(sr_settings);
+    /// let strategy = SubjectNameStrategy::TopicRecordNameStrategy(String::from("heartbeat"), String::from("nl.openweb.data.Heartbeat"));
+    /// let (bytes, header) = encoder.encode_with_header_id(vec![("beat", Value::Long(3))], strategy, false).await.unwrap();
+    ///
+    /// assert_eq!(bytes, vec![6]); // no prefix -- just the raw Avro-encoded value
+    /// assert_eq!(header.name, VALUE_SCHEMA_ID_HEADER);
+    /// assert_eq!(header.value, vec![0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn encode_with_header_id(
+        &self,
+        values: Vec<(&str, Value)>,
+        subject_name_strategy: SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let schema = self.get_schema_and_id(&key, subject_name_strategy).await?;
+        let bytes = values_to_bytes_raw(&self.resolved_cache, &schema, values)?;
+        let header = schema_id_header_for(&schema, is_key)?;
+        Ok((bytes, header))
+    }
+
     /// Encodes a struct or a primitive value to bytes. The schema used for the encoding will be
     /// retrieved from the schema registry, or it will use the one supplied with the
     /// SubjectNameStrategy.
@@ -537,6 +707,23 @@ impl<'a> AvroEncoder<'a> {
         item_to_bytes(&self.resolved_cache, &schema, item)
     }
 
+    /// Like [`AvroEncoder::encode_struct`], but returns the schema id/guid as a [`SchemaIdHeader`]
+    /// instead of prefixing the payload with it. See [`AvroEncoder::encode_with_header_id`].
+    pub async fn encode_struct_with_header_id(
+        &self,
+        item: impl Serialize,
+        subject_name_strategy: &SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let schema = self
+            .get_schema_and_id(&key, subject_name_strategy.clone())
+            .await?;
+        let bytes = item_to_bytes_raw(&self.resolved_cache, &schema, item)?;
+        let header = schema_id_header_for(&schema, is_key)?;
+        Ok((bytes, header))
+    }
+
     pub async fn encode_value(
         &self,
         item: Value,
@@ -547,6 +734,23 @@ impl<'a> AvroEncoder<'a> {
             .get_schema_and_id(&key, subject_name_strategy.clone())
             .await?;
         record_to_bytes(&self.resolved_cache, &schema, item)
+    }
+
+    /// Like [`AvroEncoder::encode_value`], but returns the schema id/guid as a [`SchemaIdHeader`]
+    /// instead of prefixing the payload with it. See [`AvroEncoder::encode_with_header_id`].
+    pub async fn encode_value_with_header_id(
+        &self,
+        item: Value,
+        subject_name_strategy: &SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let schema = self
+            .get_schema_and_id(&key, subject_name_strategy.clone())
+            .await?;
+        let bytes = record_to_bytes_raw(&self.resolved_cache, &schema, item)?;
+        let header = schema_id_header_for(&schema, is_key)?;
+        Ok((bytes, header))
     }
 
     pub async fn get_schema_and_id(
@@ -606,6 +810,24 @@ impl<'a> AvroEncoder<'a> {
     }
 }
 
+/// Builds the [`SchemaIdHeader`] for `schema`, requiring it to carry a guid (populated when the
+/// schema registry response included one, i.e. Confluent Schema Registry 8.0+). Avro has no
+/// message index, unlike protobuf, so there are no trailing bytes to append.
+fn schema_id_header_for(schema: &AvroSchema, is_key: bool) -> Result<SchemaIdHeader, SRCError> {
+    let guid = schema.guid.as_deref().ok_or_else(|| {
+        SRCError::non_retryable_without_cause(
+            "Schema registry response did not include a guid; encoding the schema id in a \
+             header requires Confluent Schema Registry 8.0+",
+        )
+    })?;
+    let name = if is_key {
+        KEY_SCHEMA_ID_HEADER
+    } else {
+        VALUE_SCHEMA_ID_HEADER
+    };
+    build_schema_id_header(name, guid, &[])
+}
+
 async fn to_avro_schema(
     sr_settings: &SrSettings,
     registered_schema: RegisteredSchema,
@@ -642,6 +864,7 @@ async fn to_avro_schema(
             version: registered_schema.version,
             properties: registered_schema.properties,
             tags: registered_schema.tags,
+            guid: registered_schema.guid,
         })),
         Err(e) => Err(SRCError::non_retryable_with_cause(
             e,
@@ -1655,6 +1878,7 @@ mod tests {
             tags: None,
             subject: None,
             version: None,
+            guid: None,
         };
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
         let result = to_avro_schema(&sr_settings, registered_schema)
@@ -1679,6 +1903,7 @@ mod tests {
             tags: None,
             subject: None,
             version: None,
+            guid: None,
         };
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
         let err = to_avro_schema(&sr_settings, registered_schema)
@@ -1691,7 +1916,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn to_avro_schema_propagates_subject_and_version() {
+    async fn to_avro_schema_propagates_subject_version_and_guid() {
         let registered_schema = RegisteredSchema {
             id: 7,
             schema_type: SchemaType::Avro,
@@ -1701,6 +1926,7 @@ mod tests {
             tags: None,
             subject: Some("orders-value".to_string()),
             version: Some(3),
+            guid: Some("cc0e0e0e-53c1-4a1a-8f1a-000000000001".to_string()),
         };
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
         let avro = to_avro_schema(&sr_settings, registered_schema)
@@ -1709,6 +1935,10 @@ mod tests {
         assert_eq!(avro.id, 7);
         assert_eq!(avro.subject.as_deref(), Some("orders-value"));
         assert_eq!(avro.version, Some(3));
+        assert_eq!(
+            avro.guid.as_deref(),
+            Some("cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+        );
     }
 
     #[tokio::test]

--- a/src/async_impl/avro.rs
+++ b/src/async_impl/avro.rs
@@ -228,10 +228,11 @@ impl<'a> AvroDecoder<'a> {
     ///
     /// # async fn doc() -> Result<(), reqwest::Error> {
     /// let mut server = Server::new_async().await;
+    /// // GET /schemas/guids/{guid} never carries an "id" field on a real registry -- only "guid".
     /// let _m = server .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
     ///     .with_status(200)
     ///     .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-    ///     .with_body(r#"{"id":1,"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
+    ///     .with_body(r#"{"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
     ///     .create();
     ///
     /// let sr_settings = SrSettings::new_builder(server.url()).no_proxy().build().unwrap();

--- a/src/async_impl/json.rs
+++ b/src/async_impl/json.rs
@@ -15,13 +15,17 @@ use valico::json_schema::schema::ScopedSchema;
 use valico::json_schema::Scope;
 
 use crate::async_impl::schema_registry::{
-    get_referenced_schema, get_schema_by_id_and_type, get_schema_by_subject, SrSettings,
+    get_referenced_schema, get_schema_by_guid_and_type, get_schema_by_id_and_type,
+    get_schema_by_subject, SrSettings,
 };
 use crate::error::SRCError;
-use crate::json_common::{fetch_fallback, fetch_id, handle_validation, to_bytes, to_value};
+use crate::json_common::{
+    fetch_fallback, fetch_id, handle_validation, to_bytes, to_bytes_raw, to_value,
+};
 use crate::schema_registry_common::{
-    get_bytes_result, invalid_bytes_error, BytesResult, RegisteredReference, RegisteredSchema,
-    SchemaType, SubjectNameStrategy,
+    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    BytesResult, HeaderSchemaId, RegisteredReference, RegisteredSchema, SchemaIdHeader, SchemaType,
+    SubjectNameStrategy, KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
 };
 
 /// Encoder that works by prepending the correct bytes in order to make it valid schema registry
@@ -66,6 +70,30 @@ impl<'a> JsonEncoder<'a> {
         let id = schema.id;
         validate(schema.clone(), value)?;
         to_bytes(id, value)
+    }
+
+    /// Like [`JsonEncoder::encode`], but instead of prefixing the payload with the schema id
+    /// (the default confluent wire format), returns the raw JSON bytes alongside a
+    /// [`SchemaIdHeader`] carrying the schema's guid. Attach the header to the Kafka record
+    /// using whatever Kafka client you're using -- this crate has no dependency on one. `is_key`
+    /// picks between the `__key_schema_id`/`__value_schema_id` header names, matching
+    /// Confluent's `HeaderSchemaIdSerializer`. See
+    /// https://github.com/gklijs/schema_registry_converter/issues/139.
+    ///
+    /// Requires a schema registry that returns a `guid` (Confluent Schema Registry 8.0+); a
+    /// registry that doesn't will make this return an error.
+    pub async fn encode_with_header_id(
+        &self,
+        value: &Value,
+        subject_name_strategy: SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let schema = self.get_schema(key, subject_name_strategy).await?;
+        validate((*schema).clone(), value)?;
+        let bytes = to_bytes_raw(value)?;
+        let header = schema_id_header_for(&schema, is_key)?;
+        Ok((bytes, header))
     }
 
     async fn get_schema(
@@ -166,6 +194,10 @@ pub struct JsonSchema {
     pub version: Option<u32>,
     pub properties: Option<HashMap<String, String>>,
     pub tags: Option<HashMap<String, Vec<String>>>,
+    /// The schema's UUID, as returned by Confluent Schema Registry 8.0+. `None` against an older
+    /// registry. Used by the `_with_header_id` encode methods to build a
+    /// [`crate::schema_registry_common::SchemaIdHeader`].
+    pub guid: Option<String>,
 }
 
 #[derive(Debug)]
@@ -173,6 +205,11 @@ pub struct JsonDecoder<'a> {
     sr_settings: SrSettings,
     direct_cache: DashMap<u32, Arc<JsonSchema>>,
     cache: DashMap<u32, SharedFutureSchema<'a>>,
+    /// Cache for schemas looked up by guid rather than id, used by
+    /// [`JsonDecoder::decode_with_header_id`]. Kept separate from `direct_cache`/`cache` (keyed
+    /// by id) since a guid and an id are different keyspaces.
+    guid_direct_cache: DashMap<String, Arc<JsonSchema>>,
+    guid_cache: DashMap<String, SharedFutureSchema<'a>>,
 }
 
 impl<'a> JsonDecoder<'a> {
@@ -188,6 +225,8 @@ impl<'a> JsonDecoder<'a> {
             sr_settings,
             direct_cache: DashMap::new(),
             cache: DashMap::new(),
+            guid_direct_cache: DashMap::new(),
+            guid_cache: DashMap::new(),
         }
     }
     /// Removes all non-retriable errors from the cache. You might need/want to run this when the
@@ -196,6 +235,10 @@ impl<'a> JsonDecoder<'a> {
     /// stored in the cache in the first place, so there's nothing to remove for those.
     pub fn remove_errors_from_cache(&self) {
         self.cache.retain(|_, v| match v.peek() {
+            Some(r) => r.is_ok(),
+            None => true,
+        });
+        self.guid_cache.retain(|_, v| match v.peek() {
             Some(r) => r.is_ok(),
             None => true,
         });
@@ -208,6 +251,43 @@ impl<'a> JsonDecoder<'a> {
             BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(
                 &invalid_bytes_error(i),
             )),
+        }
+    }
+    /// Like [`JsonDecoder::decode`], but for a message that may carry its schema id/guid in a
+    /// `__key_schema_id`/`__value_schema_id` header instead of (or in addition to) the payload
+    /// prefix, mirroring Confluent's `DualSchemaIdDeserializer`: `header_value` present ->
+    /// resolve the schema from it and treat `bytes` as the raw (unprefixed) payload;
+    /// `header_value` absent -> falls straight through to [`JsonDecoder::decode`], so the only
+    /// overhead for a caller who always passes `None` is this one check. See
+    /// https://github.com/gklijs/schema_registry_converter/issues/139.
+    pub async fn decode_with_header_id(
+        &self,
+        header_value: Option<&[u8]>,
+        bytes: Option<&[u8]>,
+    ) -> Result<Option<DecodeResult>, SRCError> {
+        let payload = match bytes {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+        match header_value {
+            None => self.decode(Some(payload)).await,
+            Some(header) => {
+                let (schema_id, _rest) = parse_schema_id_header(header)?;
+                let schema = match schema_id {
+                    HeaderSchemaId::Id(id) => self.get_schema(id).await?,
+                    HeaderSchemaId::Guid(guid) => self.get_schema_by_guid(guid).await?,
+                };
+                match serde_json::from_slice(payload) {
+                    Ok(value) => Ok(Some(DecodeResult {
+                        schema: (*schema).clone(),
+                        value,
+                    })),
+                    Err(e) => Err(SRCError::non_retryable_with_cause(
+                        e,
+                        "could not create value from bytes",
+                    )),
+                }
+            }
         }
     }
     /// The actual deserialization trying to get the id from the bytes to retrieve the schema, and
@@ -274,6 +354,68 @@ impl<'a> JsonDecoder<'a> {
             }
         }
     }
+
+    /// Like [`JsonDecoder::get_schema`], but looks the schema up by guid instead of id -- used
+    /// by [`JsonDecoder::decode_with_header_id`] when the header carries a guid rather than an
+    /// id.
+    async fn get_schema_by_guid(&self, guid: String) -> Result<Arc<JsonSchema>, SRCError> {
+        match self.guid_direct_cache.get(&guid) {
+            None => {
+                let result = self.get_schema_by_guid_shared_future(guid.clone()).await;
+                match result {
+                    Ok(v) => {
+                        if !self.guid_direct_cache.contains_key(&guid) {
+                            self.guid_direct_cache.insert(guid.clone(), v.clone());
+                            self.guid_cache.remove(&guid);
+                        }
+                        Ok(v)
+                    }
+                    Err(e) if e.retriable => {
+                        self.guid_cache.remove(&guid);
+                        Err(e)
+                    }
+                    Err(e) => Err(e.into_cache()),
+                }
+            }
+            Some(result) => Ok(result.value().clone()),
+        }
+    }
+
+    fn get_schema_by_guid_shared_future(&self, guid: String) -> SharedFutureSchema<'a> {
+        match self.guid_cache.entry(guid.clone()) {
+            Entry::Occupied(e) => e.get().clone(),
+            Entry::Vacant(e) => {
+                let sr_settings = self.sr_settings.clone();
+                let v = async move {
+                    match get_schema_by_guid_and_type(&guid, &sr_settings, SchemaType::Json).await {
+                        Ok(schema) => match to_json_schema(&sr_settings, None, schema).await {
+                            Ok(v) => Ok(Arc::new(v)),
+                            Err(e) => Err(e),
+                        },
+                        Err(e) => Err(e),
+                    }
+                }
+                .boxed()
+                .shared();
+                e.insert(v).value().clone()
+            }
+        }
+    }
+}
+
+fn schema_id_header_for(schema: &JsonSchema, is_key: bool) -> Result<SchemaIdHeader, SRCError> {
+    let guid = schema.guid.as_deref().ok_or_else(|| {
+        SRCError::non_retryable_without_cause(
+            "Schema registry response did not include a guid; encoding the schema id in a \
+             header requires Confluent Schema Registry 8.0+",
+        )
+    })?;
+    let name = if is_key {
+        KEY_SCHEMA_ID_HEADER
+    } else {
+        VALUE_SCHEMA_ID_HEADER
+    };
+    build_schema_id_header(name, guid, &[])
 }
 
 fn reference_url(rr: &RegisteredReference) -> Result<Url, SRCError> {
@@ -321,6 +463,7 @@ fn to_json_schema(
             version: registered_schema.version,
             properties: registered_schema.properties,
             tags: registered_schema.tags,
+            guid: registered_schema.guid,
         })
     }
     .boxed()
@@ -344,7 +487,7 @@ mod tests {
     use crate::async_impl::json::{to_json_schema, validate, JsonDecoder, JsonEncoder};
     use crate::async_impl::schema_registry::SrSettings;
     use crate::schema_registry_common::{
-        get_payload, RegisteredSchema, SchemaType, SubjectNameStrategy,
+        get_payload, RegisteredSchema, SchemaType, SubjectNameStrategy, VALUE_SCHEMA_ID_HEADER,
     };
     use test_utils::{
         get_json_body, get_json_body_with_reference, json_get_result_references,
@@ -363,6 +506,7 @@ mod tests {
             tags: None,
             subject: Some("orders-value".to_string()),
             version: Some(3),
+            guid: None,
         };
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
         let json_schema = to_json_schema(&sr_settings, None, registered_schema)
@@ -432,6 +576,70 @@ mod tests {
         let encoded_data = encoder.encode(&result_example, strategy).await.unwrap();
 
         assert_eq!(encoded_data, json_result_java_bytes())
+    }
+
+    #[tokio::test]
+    async fn test_encode_and_decode_with_header_id() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/subjects/testresult-value/versions/latest")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"subject":"testresult-value","version":1,"id":10,"guid":"cc0e0e0e-53c1-4a1a-8f1a-000000000001","schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let encoder = JsonEncoder::new(sr_settings.clone());
+        let strategy = SubjectNameStrategy::TopicNameStrategy(String::from("testresult"), false);
+        let value: Value = serde_json::json!({"foo": "bar"});
+
+        let (bytes, header) = encoder
+            .encode_with_header_id(&value, strategy, false)
+            .await
+            .unwrap();
+
+        assert_eq!(bytes, serde_json::to_vec(&value).unwrap());
+        assert_eq!(header.name, VALUE_SCHEMA_ID_HEADER);
+        assert_eq!(
+            header.value,
+            vec![
+                0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x01,
+            ]
+        );
+
+        let _m2 = server
+            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"id":10,"schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
+            .create();
+
+        let decoder = JsonDecoder::new(sr_settings);
+        let decoded = decoder
+            .decode_with_header_id(Some(&header.value), Some(&bytes))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.value, value);
+
+        // header absent -> falls straight through to decode(), which expects the prefix
+        let _m3 = server
+            .mock("GET", "/schemas/ids/10?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"id":10,"schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
+            .create();
+        let prefixed = get_payload(10, serde_json::to_vec(&value).unwrap());
+        let decoded = decoder
+            .decode_with_header_id(None, Some(&prefixed))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.value, value);
     }
 
     #[tokio::test]

--- a/src/async_impl/json.rs
+++ b/src/async_impl/json.rs
@@ -2,7 +2,6 @@
 //!
 //! **NOTE**: Requires the `json` feature
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use dashmap::mapref::entry::Entry;
@@ -418,10 +417,15 @@ fn schema_id_header_for(schema: &JsonSchema, is_key: bool) -> Result<SchemaIdHea
     build_schema_id_header(name, guid, &[])
 }
 
-fn reference_url(rr: &RegisteredReference) -> Result<Url, SRCError> {
-    match Url::from_str(&rr.name) {
+/// `base` is the url the referencing schema is compiled under -- a reference's `name` is
+/// resolved against it the same way a JSON Schema validator resolves a `$ref`, since that's
+/// exactly what `name` is used as inside the referencing schema. Confluent doesn't require
+/// `name` to be a fully qualified url itself (it's commonly just a bare file name like
+/// `result.json`), only that it resolves to one relative to `base`.
+fn reference_url(rr: &RegisteredReference, base: &Url) -> Result<Url, SRCError> {
+    match Url::options().base_url(Some(base)).parse(&rr.name) {
         Ok(v) => Ok(v),
-        Err(e) => Err(SRCError::non_retryable_with_cause(e, &format!("reference schema with subject {} and version {} has invalid id {}, it has to be a fully qualified url", rr.subject, rr.version, rr.name)))
+        Err(e) => Err(SRCError::non_retryable_with_cause(e, &format!("reference schema with subject {} and version {} has invalid id {}, it has to be a fully qualified url or resolve against {}", rr.subject, rr.version, rr.name, base)))
     }
 }
 
@@ -438,22 +442,25 @@ fn to_json_schema(
     registered_schema: RegisteredSchema,
 ) -> BoxFuture<Result<JsonSchema, SRCError>> {
     async move {
+        let schema: Value = to_value(&registered_schema.schema)?;
+        let url = match optional_url {
+            Some(v) => v,
+            None => main_url(&schema, sr_settings, registered_schema.id),
+        };
         let refs: Result<Vec<JsonSchema>, SRCError> = stream::iter(registered_schema.references)
-            .then(|rr| async move {
-                let url = reference_url(&rr)?;
-                let rs = get_referenced_schema(sr_settings, &rr).await?;
-                to_json_schema(sr_settings, Some(url), rs).await
+            .then(|rr| {
+                let base = url.clone();
+                async move {
+                    let ref_url = reference_url(&rr, &base)?;
+                    let rs = get_referenced_schema(sr_settings, &rr).await?;
+                    to_json_schema(sr_settings, Some(ref_url), rs).await
+                }
             })
             .collect::<Vec<_>>()
             .await
             .into_iter()
             .collect();
         let references = refs?;
-        let schema: Value = to_value(&registered_schema.schema)?;
-        let url = match optional_url {
-            Some(v) => v,
-            None => main_url(&schema, sr_settings, registered_schema.id),
-        };
         Ok(JsonSchema {
             id: registered_schema.id,
             url,
@@ -611,11 +618,12 @@ mod tests {
             ]
         );
 
+        // GET /schemas/guids/{guid} never carries an "id" field on a real registry -- only "guid".
         let _m2 = server
             .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(r#"{"id":10,"schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
+            .with_body(r#"{"schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
             .create();
 
         let decoder = JsonDecoder::new(sr_settings);
@@ -907,6 +915,43 @@ mod tests {
             }
             _ => panic!("Not an Object that was expected"),
         }
+    }
+
+    #[tokio::test]
+    async fn add_referred_schema_with_bare_reference_name() {
+        // Confluent doesn't require a reference's `name` to be a fully qualified url -- it's
+        // commonly just a bare file name like "result.json", matching what actually appears in
+        // the referencing schema's own `$ref`. Resolving it should work the same way a JSON
+        // Schema validator resolves a relative `$ref`: against the referencing schema's own
+        // (fallback, since it has no `$id`) url. See
+        // https://github.com/gklijs/schema_registry_converter/issues/139.
+        let mut server = Server::new_async().await;
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = JsonDecoder::new(sr_settings);
+
+        let schema = r#"{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"result\":{\"$ref\":\"result.json\"}},\"required\":[\"result\"]}"#;
+        let reference = r#"{"name": "result.json", "subject": "result.json", "version": 1}"#;
+
+        let _m = server
+            .mock("GET", "/schemas/ids/5?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_json_body_with_reference(schema, 5, reference))
+            .create();
+        let _m2 = server
+            .mock("GET", "/subjects/result.json/versions/1")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_json_body(json_result_schema(), 4))
+            .create();
+
+        let value = serde_json::json!({"result": {"up": "STRING", "down": "string"}});
+        let bytes = get_payload(5, serde_json::to_vec(&value).unwrap());
+        let decoded = decoder.decode(Some(&bytes)).await.unwrap().unwrap().value;
+        assert_eq!(decoded, value);
     }
 
     #[tokio::test]

--- a/src/async_impl/json.rs
+++ b/src/async_impl/json.rs
@@ -19,12 +19,13 @@ use crate::async_impl::schema_registry::{
 };
 use crate::error::SRCError;
 use crate::json_common::{
-    fetch_fallback, fetch_id, handle_validation, to_bytes, to_bytes_raw, to_value,
+    fetch_fallback, fetch_id, handle_validation, reference_depth_exceeded_error, to_bytes,
+    to_bytes_raw, to_value, MAX_REFERENCE_DEPTH,
 };
 use crate::schema_registry_common::{
-    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    get_bytes_result, invalid_bytes_error, parse_schema_id_header, schema_id_header_for,
     BytesResult, HeaderSchemaId, RegisteredReference, RegisteredSchema, SchemaIdHeader, SchemaType,
-    SubjectNameStrategy, KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
+    SubjectNameStrategy,
 };
 
 /// Encoder that works by prepending the correct bytes in order to make it valid schema registry
@@ -91,7 +92,7 @@ impl<'a> JsonEncoder<'a> {
         let schema = self.get_schema(key, subject_name_strategy).await?;
         validate((*schema).clone(), value)?;
         let bytes = to_bytes_raw(value)?;
-        let header = schema_id_header_for(&schema, is_key)?;
+        let header = schema_id_header_for(schema.guid.as_deref(), is_key, &[])?;
         Ok((bytes, header))
     }
 
@@ -138,7 +139,7 @@ impl<'a> JsonEncoder<'a> {
                 let sr_settings = self.sr_settings.clone();
                 let v = async move {
                     match get_schema_by_subject(&sr_settings, &subject_name_strategy).await {
-                        Ok(schema) => match to_json_schema(&sr_settings, None, schema).await {
+                        Ok(schema) => match to_json_schema(&sr_settings, None, schema, 0).await {
                             Ok(s) => Ok(Arc::new(s)),
                             Err(e) => Err(e),
                         },
@@ -340,7 +341,7 @@ impl<'a> JsonDecoder<'a> {
                 let sr_settings = self.sr_settings.clone();
                 let v = async move {
                     match get_schema_by_id_and_type(id, &sr_settings, SchemaType::Json).await {
-                        Ok(schema) => match to_json_schema(&sr_settings, None, schema).await {
+                        Ok(schema) => match to_json_schema(&sr_settings, None, schema, 0).await {
                             Ok(v) => Ok(Arc::new(v)),
                             Err(e) => Err(e),
                         },
@@ -387,7 +388,7 @@ impl<'a> JsonDecoder<'a> {
                 let sr_settings = self.sr_settings.clone();
                 let v = async move {
                     match get_schema_by_guid_and_type(&guid, &sr_settings, SchemaType::Json).await {
-                        Ok(schema) => match to_json_schema(&sr_settings, None, schema).await {
+                        Ok(schema) => match to_json_schema(&sr_settings, None, schema, 0).await {
                             Ok(v) => Ok(Arc::new(v)),
                             Err(e) => Err(e),
                         },
@@ -402,21 +403,6 @@ impl<'a> JsonDecoder<'a> {
     }
 }
 
-fn schema_id_header_for(schema: &JsonSchema, is_key: bool) -> Result<SchemaIdHeader, SRCError> {
-    let guid = schema.guid.as_deref().ok_or_else(|| {
-        SRCError::non_retryable_without_cause(
-            "Schema registry response did not include a guid; encoding the schema id in a \
-             header requires Confluent Schema Registry 8.0+",
-        )
-    })?;
-    let name = if is_key {
-        KEY_SCHEMA_ID_HEADER
-    } else {
-        VALUE_SCHEMA_ID_HEADER
-    };
-    build_schema_id_header(name, guid, &[])
-}
-
 /// `base` is the url the referencing schema is compiled under -- a reference's `name` is
 /// resolved against it the same way a JSON Schema validator resolves a `$ref`, since that's
 /// exactly what `name` is used as inside the referencing schema. Confluent doesn't require
@@ -429,10 +415,20 @@ fn reference_url(rr: &RegisteredReference, base: &Url) -> Result<Url, SRCError> 
     }
 }
 
-fn main_url(schema: &Value, sr_settings: &SrSettings, id: u32) -> Url {
+/// `guid` is used as the fallback label instead of `id` when `id` is the `0` placeholder
+/// [`crate::async_impl::schema_registry::get_schema_by_guid`] returns for a schema that has no
+/// real numeric id in the registry's response -- without this, every such schema without its own
+/// `$id` would collide on the same fallback url and silently share one compiled schema.
+fn main_url(schema: &Value, sr_settings: &SrSettings, id: u32, guid: Option<&str>) -> Url {
     match fetch_id(schema) {
         Some(url) => url,
-        None => fetch_fallback(sr_settings.url(), id),
+        None => {
+            let label = match guid {
+                Some(guid) if id == 0 => guid.to_string(),
+                _ => id.to_string(),
+            };
+            fetch_fallback(sr_settings.url(), &label)
+        }
     }
 }
 
@@ -440,12 +436,24 @@ fn to_json_schema(
     sr_settings: &SrSettings,
     optional_url: Option<Url>,
     registered_schema: RegisteredSchema,
+    depth: usize,
 ) -> BoxFuture<Result<JsonSchema, SRCError>> {
     async move {
+        // A circular reference chain (a schema that references itself, directly or
+        // transitively) would otherwise recurse here without bound -- each level fetches over
+        // the network, so this is reached long before it could stack-overflow.
+        if depth > MAX_REFERENCE_DEPTH {
+            return Err(reference_depth_exceeded_error());
+        }
         let schema: Value = to_value(&registered_schema.schema)?;
         let url = match optional_url {
             Some(v) => v,
-            None => main_url(&schema, sr_settings, registered_schema.id),
+            None => main_url(
+                &schema,
+                sr_settings,
+                registered_schema.id,
+                registered_schema.guid.as_deref(),
+            ),
         };
         let refs: Result<Vec<JsonSchema>, SRCError> = stream::iter(registered_schema.references)
             .then(|rr| {
@@ -453,7 +461,7 @@ fn to_json_schema(
                 async move {
                     let ref_url = reference_url(&rr, &base)?;
                     let rs = get_referenced_schema(sr_settings, &rr).await?;
-                    to_json_schema(sr_settings, Some(ref_url), rs).await
+                    to_json_schema(sr_settings, Some(ref_url), rs, depth + 1).await
                 }
             })
             .collect::<Vec<_>>()
@@ -516,7 +524,7 @@ mod tests {
             guid: None,
         };
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
-        let json_schema = to_json_schema(&sr_settings, None, registered_schema)
+        let json_schema = to_json_schema(&sr_settings, None, registered_schema, 0)
             .await
             .expect("conversion succeeds for empty references");
         assert_eq!(json_schema.id, 7);
@@ -620,7 +628,10 @@ mod tests {
 
         // GET /schemas/guids/{guid} never carries an "id" field on a real registry -- only "guid".
         let _m2 = server
-            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .mock(
+                "GET",
+                "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001?deleted=true",
+            )
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
             .with_body(r#"{"schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
@@ -992,6 +1003,45 @@ mod tests {
 
         let error = decoder.decode(Some(&bytes)).await.unwrap_err();
         assert!(error.error.starts_with("could not parse schema {"))
+    }
+
+    #[tokio::test]
+    async fn circular_reference_returns_error_instead_of_overflowing_stack() {
+        // A schema that (transitively) references itself must be rejected with a clean
+        // SRCError instead of recursing until the stack overflows. See
+        // https://github.com/gklijs/schema_registry_converter/issues/139.
+        let mut server = Server::new_async().await;
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = JsonDecoder::new(sr_settings);
+
+        let schema = r#"{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"self\":{\"$ref\":\"self.json\"}}}"#;
+        let reference = r#"{"name": "self.json", "subject": "circular", "version": 1}"#;
+
+        let _m = server
+            .mock("GET", "/schemas/ids/5?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_json_body_with_reference(schema, 5, reference))
+            .create();
+        // The reference resolves to the *same* self-referencing schema, so following it
+        // recurses into "self.json" again indefinitely.
+        let _m2 = server
+            .mock("GET", "/subjects/circular/versions/1")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_json_body_with_reference(schema, 5, reference))
+            .create();
+
+        let bytes = get_payload(5, br#"{"self":{}}"#.to_vec());
+        let error = decoder.decode(Some(&bytes)).await.unwrap_err();
+        assert!(
+            error.error.contains("reference chain exceeded"),
+            "expected a reference-depth error, got {:?}",
+            error
+        );
     }
 
     #[tokio::test]

--- a/src/async_impl/proto_decoder.rs
+++ b/src/async_impl/proto_decoder.rs
@@ -16,8 +16,25 @@ use crate::schema_registry_common::{
     get_bytes_result, parse_schema_id_header, BytesResult, HeaderSchemaId, RegisteredSchema,
     SchemaType,
 };
-use protofish::context::Context;
+use protofish::context::{Context, MessageInfo};
 use protofish::decode::{MessageValue, Value};
+
+/// `Context::get_message` returns `None` for a name it can't resolve. Surfacing that as an
+/// `SRCError` instead of panicking matters most for `decode_with_header_id`, where `full_name`
+/// is ultimately derived from Kafka header bytes a producer controls (a guid paired with a
+/// message index that doesn't actually match anything in the resolved schema), rather than from
+/// data `resolve_name` has already validated against this same context.
+fn get_message_info<'a>(
+    context: &'a Context,
+    full_name: &str,
+) -> Result<&'a MessageInfo, SRCError> {
+    context.get_message(full_name).ok_or_else(|| {
+        SRCError::non_retryable_without_cause(&format!(
+            "could not find message {} in the resolved protobuf schema",
+            full_name
+        ))
+    })
+}
 
 type SharedFutureSchema<'a> = Shared<BoxFuture<'a, Result<Arc<Vec<String>>, SRCError>>>;
 
@@ -105,7 +122,7 @@ impl<'a> ProtoDecoder<'a> {
                 let context = into_decode_context(vec_of_schemas.to_vec())?;
                 let (index, _empty) = to_index_and_data(index_bytes)?;
                 let full_name = resolve_name(&context.resolver, &index)?;
-                let message_info = context.context.get_message(&full_name).unwrap();
+                let message_info = get_message_info(&context.context, &full_name)?;
                 Ok(Value::Message(Box::from(
                     message_info.decode(payload, &context.context),
                 )))
@@ -119,7 +136,7 @@ impl<'a> ProtoDecoder<'a> {
         let context = into_decode_context(vec_of_schemas.to_vec())?;
         let (index, data) = to_index_and_data(bytes)?;
         let full_name = resolve_name(&context.resolver, &index)?;
-        let message_info = context.context.get_message(&full_name).unwrap();
+        let message_info = get_message_info(&context.context, &full_name)?;
         Ok(message_info.decode(&data, &context.context))
     }
     /// Decodes bytes into a value.
@@ -153,7 +170,7 @@ impl<'a> ProtoDecoder<'a> {
         let context = into_decode_context(vec_of_schemas.to_vec())?;
         let (index, data_bytes) = to_index_and_data(bytes)?;
         let full_name = resolve_name(&context.resolver, &index)?;
-        let message_info = context.context.get_message(&full_name).unwrap();
+        let message_info = get_message_info(&context.context, &full_name)?;
         let value = message_info.decode(&data_bytes, &context.context);
         Ok(DecodeResultWithContext {
             value,
@@ -384,7 +401,10 @@ mod tests {
     async fn test_decode_with_header_id() {
         let mut server = Server::new_async().await;
         let _m = server
-            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .mock(
+                "GET",
+                "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001?deleted=true",
+            )
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
             .with_body(get_proto_body(get_proto_hb_schema(), 1))

--- a/src/async_impl/proto_decoder.rs
+++ b/src/async_impl/proto_decoder.rs
@@ -7,12 +7,15 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::async_impl::schema_registry::{
-    get_referenced_schema, get_schema_by_id_and_type, SrSettings,
+    get_referenced_schema, get_schema_by_guid_and_type, get_schema_by_id_and_type, SrSettings,
 };
 use crate::error::SRCError;
 use crate::proto_common_types::add_common_files;
 use crate::proto_resolver::{resolve_name, to_index_and_data, MessageResolver};
-use crate::schema_registry_common::{get_bytes_result, BytesResult, RegisteredSchema, SchemaType};
+use crate::schema_registry_common::{
+    get_bytes_result, parse_schema_id_header, BytesResult, HeaderSchemaId, RegisteredSchema,
+    SchemaType,
+};
 use protofish::context::Context;
 use protofish::decode::{MessageValue, Value};
 
@@ -23,6 +26,11 @@ pub struct ProtoDecoder<'a> {
     sr_settings: SrSettings,
     direct_cache: DashMap<u32, Arc<Vec<String>>>,
     cache: DashMap<u32, SharedFutureSchema<'a>>,
+    /// Cache for schemas looked up by guid rather than id, used by
+    /// [`ProtoDecoder::decode_with_header_id`]. Kept separate from `direct_cache`/`cache`
+    /// (keyed by id) since a guid and an id are different keyspaces.
+    guid_direct_cache: DashMap<String, Arc<Vec<String>>>,
+    guid_cache: DashMap<String, SharedFutureSchema<'a>>,
 }
 
 impl<'a> ProtoDecoder<'a> {
@@ -38,6 +46,8 @@ impl<'a> ProtoDecoder<'a> {
             sr_settings,
             direct_cache: DashMap::new(),
             cache: DashMap::new(),
+            guid_direct_cache: DashMap::new(),
+            guid_cache: DashMap::new(),
         }
     }
     /// Removes all non-retriable errors from the cache. You might need/want to run this when the
@@ -46,6 +56,10 @@ impl<'a> ProtoDecoder<'a> {
     /// stored in the cache in the first place, so there's nothing to remove for those.
     pub fn remove_errors_from_cache(&self) {
         self.cache.retain(|_, v| match v.peek() {
+            Some(r) => r.is_ok(),
+            None => true,
+        });
+        self.guid_cache.retain(|_, v| match v.peek() {
             Some(r) => r.is_ok(),
             None => true,
         });
@@ -62,6 +76,40 @@ impl<'a> ProtoDecoder<'a> {
                 self.deserialize(id, bytes).await?,
             ))),
             BytesResult::Invalid(i) => Ok(Value::Bytes(Bytes::copy_from_slice(i))),
+        }
+    }
+    /// Like [`ProtoDecoder::decode`], but for a message that may carry its schema id/guid and
+    /// message index in a `__key_schema_id`/`__value_schema_id` header instead of (or in
+    /// addition to) the payload prefix, mirroring Confluent's `DualSchemaIdDeserializer`:
+    /// `header_value` present -> resolve the schema and message index from it and treat `bytes`
+    /// as the raw (unprefixed) payload; `header_value` absent -> falls straight through to
+    /// [`ProtoDecoder::decode`], so the only overhead for a caller who always passes `None` is
+    /// this one check. See https://github.com/gklijs/schema_registry_converter/issues/139.
+    pub async fn decode_with_header_id(
+        &self,
+        header_value: Option<&[u8]>,
+        bytes: Option<&[u8]>,
+    ) -> Result<Value, SRCError> {
+        let payload = match bytes {
+            Some(v) => v,
+            None => return Ok(Value::Bytes(Bytes::new())),
+        };
+        match header_value {
+            None => self.decode(Some(payload)).await,
+            Some(header) => {
+                let (schema_id, index_bytes) = parse_schema_id_header(header)?;
+                let vec_of_schemas = match schema_id {
+                    HeaderSchemaId::Id(id) => self.get_vec_of_schemas(id).await?,
+                    HeaderSchemaId::Guid(guid) => self.get_vec_of_schemas_by_guid(guid).await?,
+                };
+                let context = into_decode_context(vec_of_schemas.to_vec())?;
+                let (index, _empty) = to_index_and_data(index_bytes)?;
+                let full_name = resolve_name(&context.resolver, &index)?;
+                let message_info = context.context.get_message(&full_name).unwrap();
+                Ok(Value::Message(Box::from(
+                    message_info.decode(payload, &context.context),
+                )))
+            }
         }
     }
     /// The actual deserialization trying to get the id from the bytes to retrieve the schema, and
@@ -151,6 +199,54 @@ impl<'a> ProtoDecoder<'a> {
                 let sr_settings = self.sr_settings.clone();
                 let v = async move {
                     match get_schema_by_id_and_type(id, &sr_settings, SchemaType::Protobuf).await {
+                        Ok(v) => to_vec_of_schemas(&sr_settings, v).await,
+                        Err(e) => Err(e),
+                    }
+                }
+                .boxed()
+                .shared();
+                e.insert(v).value().clone()
+            }
+        }
+    }
+
+    /// Like [`ProtoDecoder::get_vec_of_schemas`], but looks the schema up by guid instead of id
+    /// -- used by [`ProtoDecoder::decode_with_header_id`] when the header carries a guid rather
+    /// than an id.
+    async fn get_vec_of_schemas_by_guid(&self, guid: String) -> Result<Arc<Vec<String>>, SRCError> {
+        match self.guid_direct_cache.get(&guid) {
+            None => {
+                let result = self
+                    .get_vec_of_schemas_by_guid_shared_future(guid.clone())
+                    .await;
+                match result {
+                    Ok(v) => {
+                        if !self.guid_direct_cache.contains_key(&guid) {
+                            self.guid_direct_cache.insert(guid.clone(), v.clone());
+                            self.guid_cache.remove(&guid);
+                        }
+                        Ok(v)
+                    }
+                    Err(e) if e.retriable => {
+                        self.guid_cache.remove(&guid);
+                        Err(e)
+                    }
+                    Err(e) => Err(e.into_cache()),
+                }
+            }
+            Some(result) => Ok(result.value().clone()),
+        }
+    }
+
+    fn get_vec_of_schemas_by_guid_shared_future(&self, guid: String) -> SharedFutureSchema<'a> {
+        match self.guid_cache.entry(guid.clone()) {
+            Entry::Occupied(e) => e.get().clone(),
+            Entry::Vacant(e) => {
+                let sr_settings = self.sr_settings.clone();
+                let v = async move {
+                    match get_schema_by_guid_and_type(&guid, &sr_settings, SchemaType::Protobuf)
+                        .await
+                    {
                         Ok(v) => to_vec_of_schemas(&sr_settings, v).await,
                         Err(e) => Err(e),
                     }
@@ -282,6 +378,57 @@ mod tests {
         };
 
         assert_eq!(Value::UInt64(101u64), message.fields[0].value)
+    }
+
+    #[tokio::test]
+    async fn test_decode_with_header_id() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = ProtoDecoder::new(sr_settings);
+        // magic byte 0x01 + 16-byte guid + single-message index byte 0x00
+        let header_value = [
+            0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x01, 0x00,
+        ];
+        let payload = &get_proto_hb_101()[6..]; // data only, no prefix/index
+
+        let heartbeat = decoder
+            .decode_with_header_id(Some(&header_value), Some(payload))
+            .await
+            .unwrap();
+
+        let message = match heartbeat {
+            Value::Message(x) => *x,
+            v => panic!("Other value: {:?} than expected Message", v),
+        };
+        assert_eq!(Value::UInt64(101u64), message.fields[0].value);
+
+        // header absent -> falls straight through to decode(), which expects the prefix
+        let _m2 = server
+            .mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
+            .create();
+        let heartbeat = decoder
+            .decode_with_header_id(None, Some(get_proto_hb_101()))
+            .await
+            .unwrap();
+        let message = match heartbeat {
+            Value::Message(x) => *x,
+            v => panic!("Other value: {:?} than expected Message", v),
+        };
+        assert_eq!(Value::UInt64(101u64), message.fields[0].value);
     }
 
     #[tokio::test]

--- a/src/async_impl/proto_raw.rs
+++ b/src/async_impl/proto_raw.rs
@@ -1,14 +1,16 @@
 use crate::async_impl::schema_registry::{
-    get_schema_by_id_and_type, get_schema_by_subject, SrSettings,
+    get_schema_by_guid_and_type, get_schema_by_id_and_type, get_schema_by_subject, SrSettings,
 };
 use crate::error::SRCError;
 use crate::proto_raw_common::{
-    to_bytes, to_bytes_single_message, to_decode_context, DecodeContext, EncodeContext,
+    index_bytes, index_bytes_single_message, to_bytes, to_bytes_single_message, to_decode_context,
+    DecodeContext, EncodeContext,
 };
 use crate::proto_resolver::{resolve_name, to_index_and_data, IndexResolver};
 use crate::schema_registry_common::{
-    get_bytes_result, invalid_bytes_error, BytesResult, RegisteredSchema, SchemaType,
-    SubjectNameStrategy,
+    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    BytesResult, HeaderSchemaId, RegisteredSchema, SchemaIdHeader, SchemaType, SubjectNameStrategy,
+    KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
 };
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
@@ -62,6 +64,32 @@ impl<'a> ProtoRawEncoder<'a> {
         to_bytes(&encode_context, bytes, full_name)
     }
 
+    /// Like [`ProtoRawEncoder::encode`], but instead of prefixing the payload with the schema id
+    /// (the default confluent wire format), returns the raw protobuf bytes alongside a
+    /// [`SchemaIdHeader`] carrying the schema's guid and the message index. Attach the header to
+    /// the Kafka record using whatever Kafka client you're using -- this crate has no dependency
+    /// on one. `is_key` picks between the `__key_schema_id`/`__value_schema_id` header names,
+    /// matching Confluent's `HeaderSchemaIdSerializer`. See
+    /// https://github.com/gklijs/schema_registry_converter/issues/139.
+    ///
+    /// Requires a schema registry that returns a `guid` (Confluent Schema Registry 8.0+); a
+    /// registry that doesn't will make this return an error.
+    pub async fn encode_with_header_id(
+        &self,
+        bytes: &[u8],
+        full_name: &str,
+        subject_name_strategy: SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let encode_context = self
+            .get_encoding_context(key, subject_name_strategy)
+            .await?;
+        let index = index_bytes(&encode_context, full_name)?;
+        let header = schema_id_header_for(&encode_context, &index, is_key)?;
+        Ok((bytes.to_vec(), header))
+    }
+
     /// Encodes the bytes by adding a few bytes to the message with additional information.
     /// This should only be used when the schema only had one message
     pub async fn encode_single_message(
@@ -74,6 +102,24 @@ impl<'a> ProtoRawEncoder<'a> {
             .get_encoding_context(key, subject_name_strategy)
             .await?;
         to_bytes_single_message(&encode_context, bytes)
+    }
+
+    /// Like [`ProtoRawEncoder::encode_single_message`], but returns the schema id/guid as a
+    /// [`SchemaIdHeader`] instead of prefixing the payload with it. See
+    /// [`ProtoRawEncoder::encode_with_header_id`].
+    pub async fn encode_single_message_with_header_id(
+        &self,
+        bytes: &[u8],
+        subject_name_strategy: SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let encode_context = self
+            .get_encoding_context(key, subject_name_strategy)
+            .await?;
+        let index = index_bytes_single_message(&encode_context)?;
+        let header = schema_id_header_for(&encode_context, &index, is_key)?;
+        Ok((bytes.to_vec(), header))
     }
 
     async fn get_encoding_context(
@@ -110,6 +156,7 @@ impl<'a> ProtoRawEncoder<'a> {
                     match get_schema_by_subject(&sr_settings, &subject_name_strategy).await {
                         Ok(registered_schema) => Ok(Arc::new(EncodeContext {
                             id: registered_schema.id,
+                            guid: registered_schema.guid,
                             resolver: IndexResolver::new(&registered_schema.schema),
                         })),
                         Err(e) => Err(e.into_cache()),
@@ -123,11 +170,38 @@ impl<'a> ProtoRawEncoder<'a> {
     }
 }
 
+/// Builds the [`SchemaIdHeader`] for `encode_context`, requiring it to carry a guid (populated
+/// when the schema registry response included one, i.e. Confluent Schema Registry 8.0+),
+/// appending `index` (the message index, unlike Avro/JSON which have none) after the guid.
+fn schema_id_header_for(
+    encode_context: &EncodeContext,
+    index: &[u8],
+    is_key: bool,
+) -> Result<SchemaIdHeader, SRCError> {
+    let guid = encode_context.guid.as_deref().ok_or_else(|| {
+        SRCError::non_retryable_without_cause(
+            "Schema registry response did not include a guid; encoding the schema id in a \
+             header requires Confluent Schema Registry 8.0+",
+        )
+    })?;
+    let name = if is_key {
+        KEY_SCHEMA_ID_HEADER
+    } else {
+        VALUE_SCHEMA_ID_HEADER
+    };
+    build_schema_id_header(name, guid, index)
+}
+
 #[derive(Debug)]
 pub struct ProtoRawDecoder<'a> {
     sr_settings: SrSettings,
     direct_cache: DashMap<u32, Arc<DecodeContext>>,
     cache: DashMap<u32, SharedFutureDecodeContext<'a>>,
+    /// Cache for schemas looked up by guid rather than id, used by
+    /// [`ProtoRawDecoder::decode_with_header_id`]. Kept separate from `direct_cache`/`cache`
+    /// (keyed by id) since a guid and an id are different keyspaces.
+    guid_direct_cache: DashMap<String, Arc<DecodeContext>>,
+    guid_cache: DashMap<String, SharedFutureDecodeContext<'a>>,
 }
 
 type SharedFutureDecodeContext<'a> = Shared<BoxFuture<'a, Result<Arc<DecodeContext>, SRCError>>>;
@@ -143,6 +217,8 @@ impl<'a> ProtoRawDecoder<'a> {
             sr_settings,
             direct_cache: DashMap::new(),
             cache: DashMap::new(),
+            guid_direct_cache: DashMap::new(),
+            guid_cache: DashMap::new(),
         }
     }
     /// Remove al the errors from the cache, you might need to/want to run this when a recoverable
@@ -150,6 +226,10 @@ impl<'a> ProtoRawDecoder<'a> {
     /// exist or can't be parsed.
     pub fn remove_errors_from_cache(&self) {
         self.cache.retain(|_, v| match v.peek() {
+            Some(r) => r.is_ok(),
+            None => true,
+        });
+        self.guid_cache.retain(|_, v| match v.peek() {
             Some(r) => r.is_ok(),
             None => true,
         });
@@ -162,6 +242,40 @@ impl<'a> ProtoRawDecoder<'a> {
             BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(
                 &invalid_bytes_error(i),
             )),
+        }
+    }
+    /// Like [`ProtoRawDecoder::decode`], but for a message that may carry its schema id/guid and
+    /// message index in a `__key_schema_id`/`__value_schema_id` header instead of (or in
+    /// addition to) the payload prefix, mirroring Confluent's `DualSchemaIdDeserializer`:
+    /// `header_value` present -> resolve the schema and message index from it and treat `bytes`
+    /// as the raw (unprefixed) payload; `header_value` absent -> falls straight through to
+    /// [`ProtoRawDecoder::decode`], so the only overhead for a caller who always passes `None`
+    /// is this one check. See https://github.com/gklijs/schema_registry_converter/issues/139.
+    pub async fn decode_with_header_id(
+        &self,
+        header_value: Option<&[u8]>,
+        bytes: Option<&[u8]>,
+    ) -> Result<Option<RawDecodeResult>, SRCError> {
+        let payload = match bytes {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+        match header_value {
+            None => self.decode(Some(payload)).await,
+            Some(header) => {
+                let (schema_id, index_bytes) = parse_schema_id_header(header)?;
+                let context = match schema_id {
+                    HeaderSchemaId::Id(id) => self.get_context(id).await?,
+                    HeaderSchemaId::Guid(guid) => self.get_context_by_guid(guid).await?,
+                };
+                let (index, _empty) = to_index_and_data(index_bytes)?;
+                let full_name = resolve_name(&context.resolver, &index)?;
+                Ok(Some(RawDecodeResult {
+                    schema: context.schema.clone(),
+                    full_name,
+                    bytes: payload.to_vec(),
+                }))
+            }
         }
     }
     /// The actual deserialization trying to get the id from the bytes to retrieve the schema, and
@@ -209,6 +323,44 @@ impl<'a> ProtoRawDecoder<'a> {
             }
         }
     }
+
+    /// Like [`ProtoRawDecoder::get_context`], but looks the schema up by guid instead of id --
+    /// used by [`ProtoRawDecoder::decode_with_header_id`] when the header carries a guid rather
+    /// than an id.
+    async fn get_context_by_guid(&self, guid: String) -> Result<Arc<DecodeContext>, SRCError> {
+        match self.guid_direct_cache.get(&guid) {
+            None => {
+                let result = self.get_context_by_guid_shared_future(guid.clone()).await;
+                if result.is_ok() && !self.guid_direct_cache.contains_key(&guid) {
+                    self.guid_direct_cache
+                        .insert(guid.clone(), result.clone().unwrap());
+                    self.guid_cache.remove(&guid);
+                };
+                result
+            }
+            Some(result) => Ok(result.value().clone()),
+        }
+    }
+
+    fn get_context_by_guid_shared_future(&self, guid: String) -> SharedFutureDecodeContext<'a> {
+        match self.guid_cache.entry(guid.clone()) {
+            Entry::Occupied(e) => e.get().clone(),
+            Entry::Vacant(e) => {
+                let sr_settings = self.sr_settings.clone();
+                let v = async move {
+                    match get_schema_by_guid_and_type(&guid, &sr_settings, SchemaType::Protobuf)
+                        .await
+                    {
+                        Ok(r) => Ok(Arc::new(to_decode_context(r))),
+                        Err(e) => Err(e.into_cache()),
+                    }
+                }
+                .boxed()
+                .shared();
+                e.insert(v).value().clone()
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -223,7 +375,7 @@ mod tests {
     use crate::async_impl::proto_raw::{ProtoRawDecoder, ProtoRawEncoder};
     use crate::async_impl::schema_registry::SrSettings;
     use crate::schema_registry_common::{
-        SchemaType, SubjectNameStrategy, SuppliedReference, SuppliedSchema,
+        SchemaType, SubjectNameStrategy, SuppliedReference, SuppliedSchema, VALUE_SCHEMA_ID_HEADER,
     };
     use mockito::Server;
     use test_utils::{
@@ -232,6 +384,78 @@ mod tests {
         get_proto_complex_references, get_proto_hb_101, get_proto_hb_101_empty_payload,
         get_proto_hb_101_only_data, get_proto_hb_schema, get_proto_result,
     };
+
+    #[tokio::test]
+    async fn test_encode_and_decode_with_header_id() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(format!(
+                "{{\"schema\":\"{}\", \"schemaType\":\"PROTOBUF\", \"id\":7, \"guid\":\"cc0e0e0e-53c1-4a1a-8f1a-000000000001\"}}",
+                get_proto_hb_schema()
+            ))
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let encoder = ProtoRawEncoder::new(sr_settings.clone());
+        let strategy =
+            SubjectNameStrategy::RecordNameStrategy(String::from("nl.openweb.data.Heartbeat"));
+
+        let (bytes, header) = encoder
+            .encode_with_header_id(
+                get_proto_hb_101_only_data(),
+                "nl.openweb.data.Heartbeat",
+                strategy,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(bytes, get_proto_hb_101_only_data());
+        assert_eq!(header.name, VALUE_SCHEMA_ID_HEADER);
+        assert_eq!(
+            header.value,
+            vec![
+                0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x01, 0x00, // trailing 0x00: single-message index
+            ]
+        );
+
+        let _m2 = server
+            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+
+        let decoder = ProtoRawDecoder::new(sr_settings);
+        let decoded = decoder
+            .decode_with_header_id(Some(&header.value), Some(&bytes))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.bytes, get_proto_hb_101_only_data());
+        assert_eq!(*decoded.full_name, "nl.openweb.data.Heartbeat");
+
+        // header absent -> falls straight through to decode(), which expects the prefix
+        let _m3 = server
+            .mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+        let decoded = decoder
+            .decode_with_header_id(None, Some(get_proto_hb_101()))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.bytes, get_proto_hb_101_only_data());
+    }
 
     #[tokio::test]
     async fn test_encode_default() {

--- a/src/async_impl/proto_raw.rs
+++ b/src/async_impl/proto_raw.rs
@@ -8,9 +8,8 @@ use crate::proto_raw_common::{
 };
 use crate::proto_resolver::{resolve_name, to_index_and_data, IndexResolver};
 use crate::schema_registry_common::{
-    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    get_bytes_result, invalid_bytes_error, parse_schema_id_header, schema_id_header_for,
     BytesResult, HeaderSchemaId, RegisteredSchema, SchemaIdHeader, SchemaType, SubjectNameStrategy,
-    KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
 };
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
@@ -86,7 +85,7 @@ impl<'a> ProtoRawEncoder<'a> {
             .get_encoding_context(key, subject_name_strategy)
             .await?;
         let index = index_bytes(&encode_context, full_name)?;
-        let header = schema_id_header_for(&encode_context, &index, is_key)?;
+        let header = schema_id_header_for(encode_context.guid.as_deref(), is_key, &index)?;
         Ok((bytes.to_vec(), header))
     }
 
@@ -118,7 +117,7 @@ impl<'a> ProtoRawEncoder<'a> {
             .get_encoding_context(key, subject_name_strategy)
             .await?;
         let index = index_bytes_single_message(&encode_context)?;
-        let header = schema_id_header_for(&encode_context, &index, is_key)?;
+        let header = schema_id_header_for(encode_context.guid.as_deref(), is_key, &index)?;
         Ok((bytes.to_vec(), header))
     }
 
@@ -168,28 +167,6 @@ impl<'a> ProtoRawEncoder<'a> {
             }
         }
     }
-}
-
-/// Builds the [`SchemaIdHeader`] for `encode_context`, requiring it to carry a guid (populated
-/// when the schema registry response included one, i.e. Confluent Schema Registry 8.0+),
-/// appending `index` (the message index, unlike Avro/JSON which have none) after the guid.
-fn schema_id_header_for(
-    encode_context: &EncodeContext,
-    index: &[u8],
-    is_key: bool,
-) -> Result<SchemaIdHeader, SRCError> {
-    let guid = encode_context.guid.as_deref().ok_or_else(|| {
-        SRCError::non_retryable_without_cause(
-            "Schema registry response did not include a guid; encoding the schema id in a \
-             header requires Confluent Schema Registry 8.0+",
-        )
-    })?;
-    let name = if is_key {
-        KEY_SCHEMA_ID_HEADER
-    } else {
-        VALUE_SCHEMA_ID_HEADER
-    };
-    build_schema_id_header(name, guid, index)
 }
 
 #[derive(Debug)]
@@ -295,11 +272,23 @@ impl<'a> ProtoRawDecoder<'a> {
         match self.direct_cache.get(&id) {
             None => {
                 let result = self.get_context_by_shared_future(id).await;
-                if result.is_ok() && !self.direct_cache.contains_key(&id) {
-                    self.direct_cache.insert(id, result.clone().unwrap());
-                    self.cache.remove(&id);
-                };
-                result
+                match result {
+                    Ok(v) => {
+                        if !self.direct_cache.contains_key(&id) {
+                            self.direct_cache.insert(id, v.clone());
+                            self.cache.remove(&id);
+                        }
+                        Ok(v)
+                    }
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the shared-future entry is dropped and the next call issues a
+                    // fresh request rather than replaying a stale failure.
+                    Err(e) if e.retriable => {
+                        self.cache.remove(&id);
+                        Err(e)
+                    }
+                    Err(e) => Err(e.into_cache()),
+                }
             }
             Some(result) => Ok(result.value().clone()),
         }
@@ -314,7 +303,7 @@ impl<'a> ProtoRawDecoder<'a> {
                 let v = async move {
                     match get_schema_by_id_and_type(id, &sr_settings, SchemaType::Protobuf).await {
                         Ok(r) => Ok(Arc::new(to_decode_context(r))),
-                        Err(e) => Err(e.into_cache()),
+                        Err(e) => Err(e),
                     }
                 }
                 .boxed()
@@ -331,12 +320,20 @@ impl<'a> ProtoRawDecoder<'a> {
         match self.guid_direct_cache.get(&guid) {
             None => {
                 let result = self.get_context_by_guid_shared_future(guid.clone()).await;
-                if result.is_ok() && !self.guid_direct_cache.contains_key(&guid) {
-                    self.guid_direct_cache
-                        .insert(guid.clone(), result.clone().unwrap());
-                    self.guid_cache.remove(&guid);
-                };
-                result
+                match result {
+                    Ok(v) => {
+                        if !self.guid_direct_cache.contains_key(&guid) {
+                            self.guid_direct_cache.insert(guid.clone(), v.clone());
+                            self.guid_cache.remove(&guid);
+                        }
+                        Ok(v)
+                    }
+                    Err(e) if e.retriable => {
+                        self.guid_cache.remove(&guid);
+                        Err(e)
+                    }
+                    Err(e) => Err(e.into_cache()),
+                }
             }
             Some(result) => Ok(result.value().clone()),
         }
@@ -352,7 +349,7 @@ impl<'a> ProtoRawDecoder<'a> {
                         .await
                     {
                         Ok(r) => Ok(Arc::new(to_decode_context(r))),
-                        Err(e) => Err(e.into_cache()),
+                        Err(e) => Err(e),
                     }
                 }
                 .boxed()
@@ -375,7 +372,8 @@ mod tests {
     use crate::async_impl::proto_raw::{ProtoRawDecoder, ProtoRawEncoder};
     use crate::async_impl::schema_registry::SrSettings;
     use crate::schema_registry_common::{
-        SchemaType, SubjectNameStrategy, SuppliedReference, SuppliedSchema, VALUE_SCHEMA_ID_HEADER,
+        build_schema_id_header, SchemaType, SubjectNameStrategy, SuppliedReference, SuppliedSchema,
+        VALUE_SCHEMA_ID_HEADER,
     };
     use mockito::Server;
     use test_utils::{
@@ -427,7 +425,10 @@ mod tests {
         );
 
         let _m2 = server
-            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .mock(
+                "GET",
+                "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001?deleted=true",
+            )
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
             .with_body(get_proto_body(get_proto_hb_schema(), 7))
@@ -451,6 +452,61 @@ mod tests {
             .create();
         let decoded = decoder
             .decode_with_header_id(None, Some(get_proto_hb_101()))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.bytes, get_proto_hb_101_only_data());
+    }
+
+    #[tokio::test]
+    async fn test_decode_with_header_id_guid_retriable_error_is_not_cached() {
+        // Regression test: a retriable error (e.g. a transient 503) resolving a schema by guid
+        // must not stick around in the cache, so the very next call succeeds without needing
+        // remove_errors_from_cache(). See https://github.com/gklijs/schema_registry_converter/issues/139.
+        let mut server = Server::new_async().await;
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = ProtoRawDecoder::new(sr_settings);
+        let guid = "cc0e0e0e-53c1-4a1a-8f1a-000000000001";
+        let header = build_schema_id_header(VALUE_SCHEMA_ID_HEADER, guid, &[0x00]).unwrap();
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/schemas/guids/{guid}?deleted=true").as_str(),
+            )
+            .with_status(503)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"error_code":50302,"message":"Leader not known"}"#)
+            .create();
+
+        let err = decoder
+            .decode_with_header_id(Some(&header.value), Some(get_proto_hb_101_only_data()))
+            .await
+            .unwrap_err();
+        assert!(err.retriable, "expected a retriable error, got {:?}", err);
+        assert!(
+            !err.cached,
+            "retriable error should not be cached, got {:?}",
+            err
+        );
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/schemas/guids/{guid}?deleted=true").as_str(),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+
+        // No remove_errors_from_cache() call: this must succeed purely because the retriable
+        // error above was never cached in the first place.
+        let decoded = decoder
+            .decode_with_header_id(Some(&header.value), Some(get_proto_hb_101_only_data()))
             .await
             .unwrap()
             .unwrap();

--- a/src/async_impl/schema_registry.rs
+++ b/src/async_impl/schema_registry.rs
@@ -373,7 +373,14 @@ pub async fn get_schema_by_guid(
     sr_settings: &SrSettings,
 ) -> Result<RegisteredSchema, SRCError> {
     let raw_schema = perform_sr_call(sr_settings, SrCall::GetByGuid(guid)).await?;
-    raw_to_registered_schema(raw_schema, None).await
+    // GET /schemas/guids/{guid} returns a `SchemaString` -- the same response shape as
+    // GET /schemas/ids/{id} -- which never carries an `id` field (Confluent's own model for it
+    // only has `guid`, not `id`). Unlike `get_schema_by_id`, there's no numeric id to pass in
+    // from the caller either, since not having one is the whole reason to look a schema up by
+    // guid. Default to 0 rather than erroring: nothing in the guid-based decode path depends on
+    // `RegisteredSchema.id` being a real registry id.
+    let id = raw_schema.id.unwrap_or(0);
+    raw_to_registered_schema(raw_schema, Some(id)).await
 }
 
 pub async fn get_schema_by_guid_and_type(
@@ -924,7 +931,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::async_impl::schema_registry::{
-        get_schema_by_id, get_schema_by_id_and_type, post_schema, SrSettings,
+        get_schema_by_guid, get_schema_by_id, get_schema_by_id_and_type, post_schema, SrSettings,
     };
     use crate::schema_registry_common::{
         Metadata, RawRegisteredSchema, RegisteredReference, RegisteredSchema, SchemaType,
@@ -1021,6 +1028,33 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_get_schema_by_guid_without_id_in_response() {
+        // GET /schemas/guids/{guid} returns a `SchemaString` -- same as GET /schemas/ids/{id} --
+        // which never carries an "id" field on a real Confluent Schema Registry, only "guid".
+        // See https://github.com/gklijs/schema_registry_converter/issues/139.
+        let mut server = Server::new_async().await;
+        let guid = "cc0e0e0e-53c1-4a1a-8f1a-000000000001";
+
+        let _m = server
+            .mock("GET", format!("/schemas/guids/{guid}").as_str())
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"guid":"cc0e0e0e-53c1-4a1a-8f1a-000000000001","schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}","schemaType":"AVRO"}"#)
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+
+        let result = get_schema_by_guid(guid, &sr_settings)
+            .await
+            .expect("guid lookup should succeed even without an id in the response");
+        assert_eq!(result.id, 0);
+        assert_eq!(result.guid, Some(guid.to_owned()));
     }
 
     #[tokio::test]

--- a/src/async_impl/schema_registry.rs
+++ b/src/async_impl/schema_registry.rs
@@ -1039,7 +1039,7 @@ mod tests {
         let guid = "cc0e0e0e-53c1-4a1a-8f1a-000000000001";
 
         let _m = server
-            .mock("GET", format!("/schemas/guids/{guid}").as_str())
+            .mock("GET", format!("/schemas/guids/{guid}?deleted=true").as_str())
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
             .with_body(r#"{"guid":"cc0e0e0e-53c1-4a1a-8f1a-000000000001","schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}","schemaType":"AVRO"}"#)

--- a/src/async_impl/schema_registry.rs
+++ b/src/async_impl/schema_registry.rs
@@ -365,6 +365,32 @@ pub async fn get_schema_by_id_and_type(
     }
 }
 
+/// Gets a schema by its guid. This is used to get the correct schema to deserialize bytes when
+/// the guid is carried in a Kafka header rather than the payload prefix. See
+/// https://github.com/gklijs/schema_registry_converter/issues/139.
+pub async fn get_schema_by_guid(
+    guid: &str,
+    sr_settings: &SrSettings,
+) -> Result<RegisteredSchema, SRCError> {
+    let raw_schema = perform_sr_call(sr_settings, SrCall::GetByGuid(guid)).await?;
+    raw_to_registered_schema(raw_schema, None).await
+}
+
+pub async fn get_schema_by_guid_and_type(
+    guid: &str,
+    sr_settings: &SrSettings,
+    schema_type: SchemaType,
+) -> Result<RegisteredSchema, SRCError> {
+    match get_schema_by_guid(guid, sr_settings).await {
+        Ok(v) if v.schema_type == schema_type => Ok(v),
+        Ok(v) => Err(SRCError::non_retryable_without_cause(&format!(
+            "type {:?}, is not correct",
+            v.schema_type
+        ))),
+        Err(e) => Err(e),
+    }
+}
+
 /// Gets the registered schema by supplying a SubjectNameStrategy. This is used to as part of the
 /// encoding so we get the correct schema and id, and possible references.
 pub async fn get_schema_by_subject(
@@ -438,6 +464,7 @@ async fn raw_to_registered_schema(
         tags,
         subject: raw_schema.subject,
         version: raw_schema.version,
+        guid: raw_schema.guid,
     })
 }
 
@@ -479,7 +506,8 @@ pub async fn post_schema(
         schema.tags.as_ref(),
     )
     .await;
-    let id = call_and_get_id(sr_settings, SrCall::PostNew(&subject, &body)).await?;
+    let (id, guid) =
+        call_and_get_id_and_guid(sr_settings, SrCall::PostNew(&subject, &body)).await?;
     Ok(RegisteredSchema {
         id,
         schema_type: schema.schema_type,
@@ -489,6 +517,7 @@ pub async fn post_schema(
         tags: schema.tags,
         subject: Some(subject),
         version: None,
+        guid,
     })
 }
 
@@ -532,10 +561,15 @@ async fn get_body(
     schema_element.to_string()
 }
 
-async fn call_and_get_id(sr_setting: &SrSettings, sr_call: SrCall<'_>) -> Result<u32, SRCError> {
+/// Performs a schema registry call and extracts both the id and the guid from the response
+/// (`guid` is `None` against a schema registry older than 8.0, which doesn't return one).
+async fn call_and_get_id_and_guid(
+    sr_setting: &SrSettings,
+    sr_call: SrCall<'_>,
+) -> Result<(u32, Option<String>), SRCError> {
     let raw_schema = perform_sr_call(sr_setting, sr_call).await?;
     match raw_schema.id {
-        Some(v) => Ok(v),
+        Some(v) => Ok((v, raw_schema.guid)),
         None => Err(SRCError::non_retryable_without_cause(&format!(
             "Could not get id from response for {:?}",
             sr_call
@@ -668,9 +702,10 @@ async fn perform_single_sr_call(
 ) -> Result<RawRegisteredSchema, SRCError> {
     let url = url_for_call(&sr_call, base_url);
     let builder = match sr_call {
-        SrCall::GetById(_) | SrCall::GetLatest(_) | SrCall::GetBySubjectAndVersion(_, _) => {
-            client.get(&url)
-        }
+        SrCall::GetById(_)
+        | SrCall::GetByGuid(_)
+        | SrCall::GetLatest(_)
+        | SrCall::GetBySubjectAndVersion(_, _) => client.get(&url),
         SrCall::PostNew(_, body) | SrCall::PostForVersion(_, body) => client
             .post(&url)
             .body(String::from(body))
@@ -1043,6 +1078,7 @@ mod tests {
             subject: Some("ietf-telemetry-message".to_string()),
             version: Some(1),
             id: Some(28),
+            guid: Some("32da7798-bb83-b04e-4ecd-1216eb767df2".to_string()),
             schema_type: Some("YANG".to_string()),
             references: Some(vec![
                 RegisteredReference {
@@ -1105,6 +1141,7 @@ mod tests {
             }),
             subject: Some("ietf-telemetry-message".to_string()),
             version: Some(1),
+            guid: Some("32da7798-bb83-b04e-4ecd-1216eb767df2".to_string()),
         };
 
         let parsed: RawRegisteredSchema = serde_json::from_str(json_str).expect("parse json");

--- a/src/avro_common.rs
+++ b/src/avro_common.rs
@@ -35,6 +35,9 @@ pub struct AvroSchema {
     pub version: Option<u32>,
     pub properties: Option<HashMap<String, String>>,
     pub tags: Option<HashMap<String, Vec<String>>>,
+    /// The schema's UUID, as returned by Confluent Schema Registry 8.0+. `None` against an older
+    /// registry. Used by the `_with_header_id` encode methods to build a [`crate::schema_registry_common::SchemaIdHeader`].
+    pub guid: Option<String>,
 }
 
 /// A schema's named types resolved once and reused for every subsequent encode/decode of that
@@ -187,23 +190,29 @@ pub(crate) fn replace_reference(parent: value::Value, child: value::Value) -> va
     }
 }
 
-fn to_bytes(
+/// Encodes `record` using the (cached, resolved) writer schema, without the confluent wire-format
+/// prefix -- shared by both [`to_bytes`] (prefixed, the default wire format) and the raw variants
+/// used by the `_with_header_id` encode methods, where the id/guid instead goes in a Kafka header.
+/// See https://github.com/gklijs/schema_registry_converter/issues/139.
+fn encode_value(
     cache: &ResolvedSchemaCache,
     avro_schema: &AvroSchema,
     record: Value,
 ) -> Result<Vec<u8>, SRCError> {
     let context = resolved_context(cache, avro_schema)?;
-    let result = GenericDatumWriter::builder(context.schema)
+    GenericDatumWriter::builder(context.schema)
         .resolved_schemata(context.resolved.clone())
         .build()
-        .and_then(|writer| writer.write_value_to_vec(record));
-    match result {
-        Ok(v) => Ok(get_payload(avro_schema.id, v)),
-        Err(e) => Err(SRCError::non_retryable_with_cause(
-            e,
-            "Could not get Avro bytes",
-        )),
-    }
+        .and_then(|writer| writer.write_value_to_vec(record))
+        .map_err(|e| SRCError::non_retryable_with_cause(e, "Could not get Avro bytes"))
+}
+
+fn to_bytes(
+    cache: &ResolvedSchemaCache,
+    avro_schema: &AvroSchema,
+    record: Value,
+) -> Result<Vec<u8>, SRCError> {
+    encode_value(cache, avro_schema, record).map(|v| get_payload(avro_schema.id, v))
 }
 
 /// Using the schema with a vector of values the values will be correctly deserialized according to
@@ -213,6 +222,32 @@ pub(crate) fn values_to_bytes(
     avro_schema: &AvroSchema,
     values: Vec<(&str, Value)>,
 ) -> Result<Vec<u8>, SRCError> {
+    to_bytes(
+        cache,
+        avro_schema,
+        Value::from(build_record(avro_schema, values)?),
+    )
+}
+
+/// Like [`values_to_bytes`], but without the confluent wire-format prefix -- used when the
+/// schema id/guid is carried in a Kafka header instead. See
+/// https://github.com/gklijs/schema_registry_converter/issues/139.
+pub(crate) fn values_to_bytes_raw(
+    cache: &ResolvedSchemaCache,
+    avro_schema: &AvroSchema,
+    values: Vec<(&str, Value)>,
+) -> Result<Vec<u8>, SRCError> {
+    encode_value(
+        cache,
+        avro_schema,
+        Value::from(build_record(avro_schema, values)?),
+    )
+}
+
+fn build_record<'a>(
+    avro_schema: &'a AvroSchema,
+    values: Vec<(&str, Value)>,
+) -> Result<Record<'a>, SRCError> {
     let mut record = match Record::new(&avro_schema.parsed) {
         Some(v) => v,
         None => {
@@ -226,7 +261,7 @@ pub(crate) fn values_to_bytes(
     for value in values {
         record.put(value.0, value.1)
     }
-    to_bytes(cache, avro_schema, Value::from(record))
+    Ok(record)
 }
 
 /// Using the schema with an item implementing serialize the item will be correctly deserialized
@@ -236,13 +271,28 @@ pub(crate) fn item_to_bytes(
     avro_schema: &AvroSchema,
     item: impl Serialize,
 ) -> Result<Vec<u8>, SRCError> {
+    to_bytes(cache, avro_schema, resolve_item(avro_schema, item)?)
+}
+
+/// Like [`item_to_bytes`], but without the confluent wire-format prefix -- used when the schema
+/// id/guid is carried in a Kafka header instead. See
+/// https://github.com/gklijs/schema_registry_converter/issues/139.
+pub(crate) fn item_to_bytes_raw(
+    cache: &ResolvedSchemaCache,
+    avro_schema: &AvroSchema,
+    item: impl Serialize,
+) -> Result<Vec<u8>, SRCError> {
+    encode_value(cache, avro_schema, resolve_item(avro_schema, item)?)
+}
+
+fn resolve_item(avro_schema: &AvroSchema, item: impl Serialize) -> Result<Value, SRCError> {
     match to_value(item)
         .map_err(|e| {
             SRCError::non_retryable_with_cause(e, "Could not transform to apache_avro value")
         })
         .map(|r| r.resolve(&avro_schema.parsed))
     {
-        Ok(Ok(v)) => to_bytes(cache, avro_schema, v),
+        Ok(Ok(v)) => Ok(v),
         Ok(Err(e)) => Err(SRCError::non_retryable_with_cause(e, "Failed to resolve")),
         Err(e) => Err(e),
     }
@@ -254,6 +304,17 @@ pub(crate) fn record_to_bytes(
     item: Value,
 ) -> Result<Vec<u8>, SRCError> {
     to_bytes(cache, avro_schema, item)
+}
+
+/// Like [`record_to_bytes`], but without the confluent wire-format prefix -- used when the schema
+/// id/guid is carried in a Kafka header instead. See
+/// https://github.com/gklijs/schema_registry_converter/issues/139.
+pub(crate) fn record_to_bytes_raw(
+    cache: &ResolvedSchemaCache,
+    avro_schema: &AvroSchema,
+    item: Value,
+) -> Result<Vec<u8>, SRCError> {
+    encode_value(cache, avro_schema, item)
 }
 
 pub(crate) fn get_name(schema: &Schema) -> Option<Name> {
@@ -302,6 +363,7 @@ mod tests {
             version: None,
             properties: None,
             tags: None,
+            guid: None,
         };
         let result = values_to_bytes(&DashMap::new(), &schema, vec![("beat", Value::Long(3))]);
         assert_eq!(
@@ -324,6 +386,7 @@ mod tests {
             version: None,
             properties: None,
             tags: None,
+            guid: None,
         };
         let err =
             values_to_bytes(&DashMap::new(), &schema, vec![("beat", Value::Long(3))]).unwrap_err();
@@ -344,6 +407,7 @@ mod tests {
             version: None,
             properties: None,
             tags: None,
+            guid: None,
         };
         let err =
             crate::avro_common::item_to_bytes(&DashMap::new(), &schema, Heartbeat { beat: 3 })
@@ -365,6 +429,7 @@ mod tests {
             version: None,
             properties: None,
             tags: None,
+            guid: None,
         };
         let item = ConfirmAccountCreation {
             id: [

--- a/src/blocking/avro.rs
+++ b/src/blocking/avro.rs
@@ -45,9 +45,9 @@ use crate::blocking::schema_registry::{
 };
 use crate::error::SRCError;
 use crate::schema_registry_common::{
-    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    get_bytes_result, invalid_bytes_error, parse_schema_id_header, schema_id_header_for,
     BytesResult, HeaderSchemaId, RegisteredReference, RegisteredSchema, SchemaIdHeader, SchemaType,
-    SubjectNameStrategy, KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
+    SubjectNameStrategy,
 };
 
 /// A decoder used to transform bytes to a Value object
@@ -209,7 +209,7 @@ impl AvroDecoder {
     ///
     /// let mut server = mockito::Server::new();
     /// // GET /schemas/guids/{guid} never carries an "id" field on a real registry -- only "guid".
-    /// let _m = server .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+    /// let _m = server .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001?deleted=true")
     ///     .with_status(200)
     ///     .with_header("content-type", "application/vnd.schemaregistry.v1+json")
     ///     .with_body(r#"{"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
@@ -556,7 +556,7 @@ impl AvroEncoder {
         let key = subject_name_strategy.get_subject()?;
         let avro_schema = self.get_schema_and_id(key, subject_name_strategy)?;
         let bytes = values_to_bytes_raw(&self.resolved_cache, &avro_schema, values)?;
-        let header = schema_id_header_for(&avro_schema, is_key)?;
+        let header = schema_id_header_for(avro_schema.guid.as_deref(), is_key, &[])?;
         Ok((bytes, header))
     }
 
@@ -629,7 +629,7 @@ impl AvroEncoder {
         let key = subject_name_strategy.get_subject()?;
         let avro_schema = self.get_schema_and_id(key, subject_name_strategy)?;
         let bytes = item_to_bytes_raw(&self.resolved_cache, &avro_schema, item)?;
-        let header = schema_id_header_for(&avro_schema, is_key)?;
+        let header = schema_id_header_for(avro_schema.guid.as_deref(), is_key, &[])?;
         Ok((bytes, header))
     }
 
@@ -690,24 +690,6 @@ fn add_references(
         new_value = add_references(sr_settings, new_value, &registered_schema.references)?;
     }
     Ok(new_value)
-}
-
-/// Builds the [`SchemaIdHeader`] for `schema`, requiring it to carry a guid (populated when the
-/// schema registry response included one, i.e. Confluent Schema Registry 8.0+). Avro has no
-/// message index, unlike protobuf, so there are no trailing bytes to append.
-fn schema_id_header_for(schema: &AvroSchema, is_key: bool) -> Result<SchemaIdHeader, SRCError> {
-    let guid = schema.guid.as_deref().ok_or_else(|| {
-        SRCError::non_retryable_without_cause(
-            "Schema registry response did not include a guid; encoding the schema id in a \
-             header requires Confluent Schema Registry 8.0+",
-        )
-    })?;
-    let name = if is_key {
-        KEY_SCHEMA_ID_HEADER
-    } else {
-        VALUE_SCHEMA_ID_HEADER
-    };
-    build_schema_id_header(name, guid, &[])
 }
 
 fn to_avro_schema(

--- a/src/blocking/avro.rs
+++ b/src/blocking/avro.rs
@@ -208,10 +208,11 @@ impl AvroDecoder {
     /// use schema_registry_converter::blocking::schema_registry::SrSettings;
     ///
     /// let mut server = mockito::Server::new();
+    /// // GET /schemas/guids/{guid} never carries an "id" field on a real registry -- only "guid".
     /// let _m = server .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
     ///     .with_status(200)
     ///     .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-    ///     .with_body(r#"{"id":1,"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
+    ///     .with_body(r#"{"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
     ///     .create();
     ///
     /// let sr_settings = SrSettings::new_builder(server.url()).no_proxy().build().unwrap();

--- a/src/blocking/avro.rs
+++ b/src/blocking/avro.rs
@@ -36,16 +36,18 @@ use serde::ser::Serialize;
 use serde_json::Value as JsonValue;
 
 use crate::avro_common::{
-    decode_bytes, get_name, item_to_bytes, replace_reference, values_to_bytes, AvroSchema,
-    DecodeResult, DecodeResultWithSchema, ResolvedSchemaCache,
+    decode_bytes, get_name, item_to_bytes, item_to_bytes_raw, replace_reference, values_to_bytes,
+    values_to_bytes_raw, AvroSchema, DecodeResult, DecodeResultWithSchema, ResolvedSchemaCache,
 };
 use crate::blocking::schema_registry::{
-    get_referenced_schema, get_schema_by_id_and_type, get_schema_by_subject, SrSettings,
+    get_referenced_schema, get_schema_by_guid_and_type, get_schema_by_id_and_type,
+    get_schema_by_subject, SrSettings,
 };
 use crate::error::SRCError;
 use crate::schema_registry_common::{
-    get_bytes_result, invalid_bytes_error, BytesResult, RegisteredReference, RegisteredSchema,
-    SchemaType, SubjectNameStrategy,
+    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    BytesResult, HeaderSchemaId, RegisteredReference, RegisteredSchema, SchemaIdHeader, SchemaType,
+    SubjectNameStrategy, KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
 };
 
 /// A decoder used to transform bytes to a Value object
@@ -81,6 +83,10 @@ use crate::schema_registry_common::{
 pub struct AvroDecoder {
     sr_settings: SrSettings,
     cache: DashMap<u32, Result<Arc<AvroSchema>, SRCError>>,
+    /// Cache for schemas looked up by guid rather than id, used by
+    /// [`AvroDecoder::decode_with_header_id`]. Kept separate from `cache` (keyed by id) since a
+    /// guid and an id are different keyspaces.
+    guid_cache: DashMap<String, Result<Arc<AvroSchema>, SRCError>>,
     resolved_cache: ResolvedSchemaCache,
 }
 
@@ -96,6 +102,7 @@ impl AvroDecoder {
         AvroDecoder {
             sr_settings,
             cache: DashMap::new(),
+            guid_cache: DashMap::new(),
             resolved_cache: DashMap::new(),
         }
     }
@@ -140,6 +147,7 @@ impl AvroDecoder {
     /// ```
     pub fn remove_errors_from_cache(&self) {
         self.cache.retain(|_, v| v.is_ok());
+        self.guid_cache.retain(|_, v| v.is_ok());
     }
     /// Decodes bytes into a value.
     /// The choice to use Option<&[u8]> as type us made so it plays nice with the BorrowedMessage
@@ -185,6 +193,64 @@ impl AvroDecoder {
                 Err(e) => Err(e),
             },
             Err(e) => Err(e),
+        }
+    }
+    /// Like [`AvroDecoder::decode`], but for a message that may carry its schema id/guid in a
+    /// `__key_schema_id`/`__value_schema_id` header instead of (or in addition to) the payload
+    /// prefix, mirroring Confluent's `DualSchemaIdDeserializer`: `header_value` present ->
+    /// resolve the schema from it and treat `bytes` as the raw (unprefixed) payload;
+    /// `header_value` absent -> falls straight through to [`AvroDecoder::decode`], so the only
+    /// overhead for a caller who always passes `None` is this one check. See
+    /// https://github.com/gklijs/schema_registry_converter/issues/139.
+    /// ```
+    /// use apache_avro::types::Value;
+    /// use schema_registry_converter::blocking::avro::AvroDecoder;
+    /// use schema_registry_converter::blocking::schema_registry::SrSettings;
+    ///
+    /// let mut server = mockito::Server::new();
+    /// let _m = server .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+    ///     .with_status(200)
+    ///     .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+    ///     .with_body(r#"{"id":1,"schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
+    ///     .create();
+    ///
+    /// let sr_settings = SrSettings::new_builder(server.url()).no_proxy().build().unwrap();
+    /// let decoder = AvroDecoder::new(sr_settings);
+    /// let header_value = [0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
+    /// let heartbeat = decoder.decode_with_header_id(Some(&header_value), Some(&[6])).unwrap().value;
+    ///
+    /// assert_eq!(heartbeat, Value::Record(vec![("beat".to_string(), Value::Long(3))]))
+    /// ```
+    pub fn decode_with_header_id(
+        &self,
+        header_value: Option<&[u8]>,
+        bytes: Option<&[u8]>,
+    ) -> Result<DecodeResult, SRCError> {
+        let payload = match bytes {
+            Some(v) => v,
+            None => {
+                return Ok(DecodeResult {
+                    name: None,
+                    value: Value::Null,
+                });
+            }
+        };
+        match header_value {
+            None => self.decode(Some(payload)),
+            Some(header) => {
+                let (schema_id, _rest) = parse_schema_id_header(header)?;
+                let schema = match schema_id {
+                    HeaderSchemaId::Id(id) => self.schema(id)?,
+                    HeaderSchemaId::Guid(guid) => self.guid_schema(guid)?,
+                };
+                match decode_bytes(&self.resolved_cache, &schema, payload) {
+                    Ok(v) => Ok(DecodeResult {
+                        name: get_name(&schema.parsed),
+                        value: v,
+                    }),
+                    Err(e) => Err(e),
+                }
+            }
         }
     }
     /// Decodes bytes into a value.
@@ -240,6 +306,29 @@ impl AvroDecoder {
                     // Retriable errors (transient network/HTTP issues) don't make sense to
                     // cache, so the entry is left vacant and the next call issues a fresh
                     // request rather than replaying a stale failure.
+                    Err(e) if e.retriable => Err(e),
+                    result => entry
+                        .insert(result.map_err(SRCError::into_cache))
+                        .value()
+                        .clone(),
+                }
+            }
+        }
+    }
+
+    /// Like [`AvroDecoder::schema`], but looks the schema up by guid instead of id -- used by
+    /// [`AvroDecoder::decode_with_header_id`] when the header carries a guid rather than an id.
+    fn guid_schema(&self, guid: String) -> Result<Arc<AvroSchema>, SRCError> {
+        let sr_settings = &self.sr_settings;
+        match self.guid_cache.entry(guid.clone()) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let result = match get_schema_by_guid_and_type(&guid, sr_settings, SchemaType::Avro)
+                {
+                    Ok(registered_schema) => to_avro_schema(sr_settings, registered_schema),
+                    Err(e) => Err(e),
+                };
+                match result {
                     Err(e) if e.retriable => Err(e),
                     result => entry
                         .insert(result.map_err(SRCError::into_cache))
@@ -425,6 +514,51 @@ impl AvroEncoder {
         }
     }
 
+    /// Like [`AvroEncoder::encode`], but instead of prefixing the payload with the schema id
+    /// (the default confluent wire format), returns the raw Avro bytes alongside a
+    /// [`SchemaIdHeader`] carrying the schema's guid. Attach the header to the Kafka record
+    /// using whatever Kafka client you're using -- this crate has no dependency on one. `is_key`
+    /// picks between the `__key_schema_id`/`__value_schema_id` header names, matching
+    /// Confluent's `HeaderSchemaIdSerializer`. See
+    /// https://github.com/gklijs/schema_registry_converter/issues/139.
+    ///
+    /// Requires a schema registry that returns a `guid` (Confluent Schema Registry 8.0+); a
+    /// registry that doesn't will make this return an error.
+    /// ```
+    /// use apache_avro::types::Value;
+    /// use schema_registry_converter::blocking::avro::AvroEncoder;
+    /// use schema_registry_converter::schema_registry_common::{SubjectNameStrategy, VALUE_SCHEMA_ID_HEADER};
+    /// use schema_registry_converter::blocking::schema_registry::SrSettings;
+    ///
+    /// let mut server = mockito::Server::new();
+    /// let _m = server .mock("GET", "/subjects/heartbeat-nl.openweb.data.Heartbeat/versions/latest")
+    ///     .with_status(200)
+    ///     .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+    ///     .with_body(r#"{"subject":"heartbeat-value","version":1,"id":3,"guid":"cc0e0e0e-53c1-4a1a-8f1a-000000000001","schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}"}"#)
+    ///     .create();
+    ///
+    /// let sr_settings = SrSettings::new_builder(server.url()).no_proxy().build().unwrap();
+    /// let encoder = AvroEncoder::new(sr_settings);
+    /// let strategy = SubjectNameStrategy::TopicRecordNameStrategy(String::from("heartbeat"), String::from("nl.openweb.data.Heartbeat"));
+    /// let (bytes, header) = encoder.encode_with_header_id(vec![("beat", Value::Long(3))], &strategy, false).unwrap();
+    ///
+    /// assert_eq!(bytes, vec![6]); // no prefix -- just the raw Avro-encoded value
+    /// assert_eq!(header.name, VALUE_SCHEMA_ID_HEADER);
+    /// assert_eq!(header.value, vec![0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]);
+    /// ```
+    pub fn encode_with_header_id(
+        &self,
+        values: Vec<(&str, Value)>,
+        subject_name_strategy: &SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let avro_schema = self.get_schema_and_id(key, subject_name_strategy)?;
+        let bytes = values_to_bytes_raw(&self.resolved_cache, &avro_schema, values)?;
+        let header = schema_id_header_for(&avro_schema, is_key)?;
+        Ok((bytes, header))
+    }
+
     /// Encodes a struct or a primitive value to bytes. The schema used for the encoding will be
     /// retrieved from the schema registry, or it will use the one supplied with the
     /// SubjectNameStrategy.
@@ -480,6 +614,22 @@ impl AvroEncoder {
             Ok(avro_schema) => item_to_bytes(&self.resolved_cache, &avro_schema, item),
             Err(e) => Err(e),
         }
+    }
+
+    /// Like [`AvroEncoder::encode_struct`], but returns the schema id/guid as a
+    /// [`SchemaIdHeader`] instead of prefixing the payload with it. See
+    /// [`AvroEncoder::encode_with_header_id`].
+    pub fn encode_struct_with_header_id(
+        &self,
+        item: impl Serialize,
+        subject_name_strategy: &SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let avro_schema = self.get_schema_and_id(key, subject_name_strategy)?;
+        let bytes = item_to_bytes_raw(&self.resolved_cache, &avro_schema, item)?;
+        let header = schema_id_header_for(&avro_schema, is_key)?;
+        Ok((bytes, header))
     }
 
     fn get_schema_and_id(
@@ -541,6 +691,24 @@ fn add_references(
     Ok(new_value)
 }
 
+/// Builds the [`SchemaIdHeader`] for `schema`, requiring it to carry a guid (populated when the
+/// schema registry response included one, i.e. Confluent Schema Registry 8.0+). Avro has no
+/// message index, unlike protobuf, so there are no trailing bytes to append.
+fn schema_id_header_for(schema: &AvroSchema, is_key: bool) -> Result<SchemaIdHeader, SRCError> {
+    let guid = schema.guid.as_deref().ok_or_else(|| {
+        SRCError::non_retryable_without_cause(
+            "Schema registry response did not include a guid; encoding the schema id in a \
+             header requires Confluent Schema Registry 8.0+",
+        )
+    })?;
+    let name = if is_key {
+        KEY_SCHEMA_ID_HEADER
+    } else {
+        VALUE_SCHEMA_ID_HEADER
+    };
+    build_schema_id_header(name, guid, &[])
+}
+
 fn to_avro_schema(
     sr_settings: &SrSettings,
     registered_schema: RegisteredSchema,
@@ -572,6 +740,7 @@ fn to_avro_schema(
             version: registered_schema.version,
             properties: registered_schema.properties,
             tags: registered_schema.tags,
+            guid: registered_schema.guid,
         })),
         Err(e) => Err(SRCError::non_retryable_with_cause(
             e,
@@ -1517,6 +1686,7 @@ mod tests {
             tags: None,
             subject: None,
             version: None,
+            guid: None,
         };
         let sr_settings = SrSettings::new_builder(String::from("http://127.0.0.1:1234"))
             .no_proxy()
@@ -1542,6 +1712,7 @@ mod tests {
             tags: None,
             subject: None,
             version: None,
+            guid: None,
         };
         let sr_settings = SrSettings::new_builder(String::from("http://127.0.0.1:1234"))
             .no_proxy()
@@ -1558,7 +1729,7 @@ mod tests {
     }
 
     #[test]
-    fn to_avro_schema_propagates_subject_and_version() {
+    fn to_avro_schema_propagates_subject_version_and_guid() {
         let registered_schema = RegisteredSchema {
             id: 7,
             schema_type: SchemaType::Avro,
@@ -1568,6 +1739,7 @@ mod tests {
             tags: None,
             subject: Some("orders-value".to_string()),
             version: Some(3),
+            guid: Some("cc0e0e0e-53c1-4a1a-8f1a-000000000001".to_string()),
         };
         let sr_settings = SrSettings::new_builder(String::from("http://127.0.0.1:1234"))
             .no_proxy()
@@ -1578,6 +1750,10 @@ mod tests {
         assert_eq!(avro.id, 7);
         assert_eq!(avro.subject.as_deref(), Some("orders-value"));
         assert_eq!(avro.version, Some(3));
+        assert_eq!(
+            avro.guid.as_deref(),
+            Some("cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+        );
     }
 
     #[test]

--- a/src/blocking/json.rs
+++ b/src/blocking/json.rs
@@ -1,6 +1,5 @@
 use std::collections::hash_map::{Entry, RandomState};
 use std::collections::HashMap;
-use std::str::FromStr;
 
 use serde_json::Value;
 use url::Url;
@@ -339,23 +338,32 @@ impl JsonDecoder {
     }
 }
 
+/// `base` is the url the referencing schema is compiled under -- a reference's `name` is
+/// resolved against it the same way a JSON Schema validator resolves a `$ref`, since that's
+/// exactly what `name` is used as inside the referencing schema. Confluent doesn't require
+/// `name` to be a fully qualified url itself (it's commonly just a bare file name like
+/// `result.json`), only that it resolves to one relative to `base`.
 fn add_refs_to_scope(
     scope: &mut Scope,
     sr_settings: &SrSettings,
+    base: &Url,
     refs: &[RegisteredReference],
 ) -> Result<(), SRCError> {
     for rr in refs.iter() {
-        let rs = get_referenced_schema(sr_settings, rr)?;
-        let id = match Url::from_str(&rr.name) {
+        let id = match Url::options().base_url(Some(base)).parse(&rr.name) {
             Ok(v) => v,
-            Err(e) => return Err(SRCError::non_retryable_with_cause(e, &format!("reference schema with subject {} and version {} has invalid id {}, it has to be a fully qualified url", rr.subject, rr.version, rr.name)))
+            Err(e) => return Err(SRCError::non_retryable_with_cause(e, &format!("reference schema with subject {} and version {} has invalid id {}, it has to be a fully qualified url or resolve against {}", rr.subject, rr.version, rr.name, base)))
         };
         // if it's already part of the scope, it's assumed any references are also already part of the scope.
         if scope.resolve(&id).is_some() {
             continue;
         }
-        add_refs_to_scope(scope, sr_settings, &rs.references)?;
+        let rs = get_referenced_schema(sr_settings, rr)?;
         let def: Value = to_value(&rs.schema)?;
+        // A referenced schema with its own `$id` establishes a new base for its own references;
+        // otherwise nested refs resolve against the url it was just compiled under.
+        let nested_base = fetch_id(&def).unwrap_or_else(|| id.clone());
+        add_refs_to_scope(scope, sr_settings, &nested_base, &rs.references)?;
         scope.compile_with_id(&id, def, false).unwrap();
     }
     Ok(())
@@ -366,7 +374,6 @@ fn set_scoped_schema(
     sr_settings: &SrSettings,
     registered_schema: &RegisteredSchema,
 ) -> Result<Url, SRCError> {
-    add_refs_to_scope(scope, sr_settings, &registered_schema.references)?;
     let def: Value = match serde_json::from_str(&registered_schema.schema) {
         Ok(v) => v,
         Err(e) => {
@@ -391,6 +398,7 @@ fn set_scoped_schema(
     if scope.resolve(&id).is_some() {
         return Ok(id);
     }
+    add_refs_to_scope(scope, sr_settings, &id, &registered_schema.references)?;
     match scope.compile_with_id(&id, def, false) {
         Ok(_) => (),
         Err(e) => {
@@ -503,11 +511,12 @@ mod tests {
             ]
         );
 
+        // GET /schemas/guids/{guid} never carries an "id" field on a real registry -- only "guid".
         let _m2 = server
             .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
-            .with_body(r#"{"id":10,"schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
+            .with_body(r#"{"schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
             .create();
 
         let mut decoder = JsonDecoder::new(sr_settings);
@@ -809,6 +818,47 @@ mod tests {
             }
             _ => panic!("Not an Object that was expected"),
         }
+    }
+
+    #[test]
+    fn add_referred_schema_with_bare_reference_name() {
+        // Confluent doesn't require a reference's `name` to be a fully qualified url -- it's
+        // commonly just a bare file name like "result.json", matching what actually appears in
+        // the referencing schema's own `$ref`. Resolving it should work the same way a JSON
+        // Schema validator resolves a relative `$ref`: against the referencing schema's own
+        // (fallback, since it has no `$id`) url. See
+        // https://github.com/gklijs/schema_registry_converter/issues/139.
+        let mut server = mockito::Server::new();
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let mut decoder = JsonDecoder::new(sr_settings);
+
+        let schema = r#"{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"result\":{\"$ref\":\"result.json\"}},\"required\":[\"result\"]}"#;
+        let reference = r#"{"name": "result.json", "subject": "result.json", "version": 1}"#;
+
+        let _m = server
+            .mock("GET", "/schemas/ids/5?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_json_body_with_reference(schema, 5, reference))
+            .create();
+        let _m2 = server
+            .mock("GET", "/subjects/result.json/versions/1")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_json_body(json_result_schema(), 4))
+            .create();
+
+        let value = serde_json::json!({"result": {"up": "STRING", "down": "string"}});
+        let bytes = get_payload(5, serde_json::to_vec(&value).unwrap());
+        let result = match decoder.decode(Some(&bytes)) {
+            Ok(Some(v)) => v.value,
+            Err(e) => panic!("Error decoding: {}", e),
+            _ => panic!("Not a value while that was expected"),
+        };
+        assert_eq!(result, value);
     }
 
     #[test]

--- a/src/blocking/json.rs
+++ b/src/blocking/json.rs
@@ -12,12 +12,13 @@ use crate::blocking::schema_registry::{
 };
 use crate::error::SRCError;
 use crate::json_common::{
-    fetch_fallback, fetch_id, handle_validation, to_bytes, to_bytes_raw, to_value,
+    fetch_fallback, fetch_id, handle_validation, reference_depth_exceeded_error, to_bytes,
+    to_bytes_raw, to_value, MAX_REFERENCE_DEPTH,
 };
 use crate::schema_registry_common::{
-    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    get_bytes_result, invalid_bytes_error, parse_schema_id_header, schema_id_header_for,
     BytesResult, HeaderSchemaId, RegisteredReference, RegisteredSchema, SchemaIdHeader, SchemaType,
-    SubjectNameStrategy, KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
+    SubjectNameStrategy,
 };
 
 /// Encoder that works by prepending the correct bytes in order to make it valid schema registry
@@ -148,13 +149,17 @@ impl JsonEncoder {
             Ok(c) => c.clone(),
             Err(e) => return Err(e.clone()),
         };
-        if self.scope.resolve(&context.url).is_none() {
-            return Err(SRCError::non_retryable_without_cause(
-                "could not get schema from scope",
-            ));
-        }
+        let validation = match self.scope.resolve(&context.url) {
+            Some(schema) => schema.validate(value),
+            None => {
+                return Err(SRCError::non_retryable_without_cause(
+                    "could not get schema from scope",
+                ))
+            }
+        };
+        handle_validation(validation, value)?;
         let bytes = to_bytes_raw(value)?;
-        let header = schema_id_header_for(context.guid.as_deref(), is_key)?;
+        let header = schema_id_header_for(context.guid.as_deref(), is_key, &[])?;
         Ok((bytes, header))
     }
 }
@@ -164,21 +169,6 @@ struct EncodeContext {
     id: u32,
     url: Url,
     guid: Option<String>,
-}
-
-fn schema_id_header_for(guid: Option<&str>, is_key: bool) -> Result<SchemaIdHeader, SRCError> {
-    let guid = guid.ok_or_else(|| {
-        SRCError::non_retryable_without_cause(
-            "Schema registry response did not include a guid; encoding the schema id in a \
-             header requires Confluent Schema Registry 8.0+",
-        )
-    })?;
-    let name = if is_key {
-        KEY_SCHEMA_ID_HEADER
-    } else {
-        VALUE_SCHEMA_ID_HEADER
-    };
-    build_schema_id_header(name, guid, &[])
 }
 
 #[derive(Debug)]
@@ -348,7 +338,11 @@ fn add_refs_to_scope(
     sr_settings: &SrSettings,
     base: &Url,
     refs: &[RegisteredReference],
+    depth: usize,
 ) -> Result<(), SRCError> {
+    if depth > MAX_REFERENCE_DEPTH {
+        return Err(reference_depth_exceeded_error());
+    }
     for rr in refs.iter() {
         let id = match Url::options().base_url(Some(base)).parse(&rr.name) {
             Ok(v) => v,
@@ -363,7 +357,7 @@ fn add_refs_to_scope(
         // A referenced schema with its own `$id` establishes a new base for its own references;
         // otherwise nested refs resolve against the url it was just compiled under.
         let nested_base = fetch_id(&def).unwrap_or_else(|| id.clone());
-        add_refs_to_scope(scope, sr_settings, &nested_base, &rs.references)?;
+        add_refs_to_scope(scope, sr_settings, &nested_base, &rs.references, depth + 1)?;
         scope.compile_with_id(&id, def, false).unwrap();
     }
     Ok(())
@@ -388,7 +382,16 @@ fn set_scoped_schema(
     };
     let id = match fetch_id(&def) {
         Some(url) => url,
-        None => fetch_fallback(sr_settings.url(), registered_schema.id),
+        None => {
+            // A schema resolved only by guid (`get_schema_by_guid`) never gets a real numeric
+            // id back from the registry -- `id` is a `0` placeholder in that case. Fall back to
+            // the guid instead so two different such schemas don't collide on the same url.
+            let label = match &registered_schema.guid {
+                Some(guid) if registered_schema.id == 0 => guid.clone(),
+                _ => registered_schema.id.to_string(),
+            };
+            fetch_fallback(sr_settings.url(), &label)
+        }
     };
     // Same schema can now be reached through two independent caches -- by id (`schema`) and by
     // guid (`guid_schema`) -- sharing this one `scope`. If it's already compiled under this url
@@ -398,7 +401,7 @@ fn set_scoped_schema(
     if scope.resolve(&id).is_some() {
         return Ok(id);
     }
-    add_refs_to_scope(scope, sr_settings, &id, &registered_schema.references)?;
+    add_refs_to_scope(scope, sr_settings, &id, &registered_schema.references, 0)?;
     match scope.compile_with_id(&id, def, false) {
         Ok(_) => (),
         Err(e) => {
@@ -427,7 +430,9 @@ mod tests {
     use crate::blocking::json::{JsonDecoder, JsonEncoder};
     use crate::blocking::schema_registry::SrSettings;
     use crate::json_common::handle_validation;
-    use crate::schema_registry_common::{get_payload, SubjectNameStrategy, VALUE_SCHEMA_ID_HEADER};
+    use crate::schema_registry_common::{
+        build_schema_id_header, get_payload, SubjectNameStrategy, VALUE_SCHEMA_ID_HEADER,
+    };
     use test_utils::{
         get_json_body, get_json_body_with_reference, json_extra_schema, json_get_extra_references,
         json_get_result_references, json_incorrect_bytes, json_result_java_bytes,
@@ -513,7 +518,10 @@ mod tests {
 
         // GET /schemas/guids/{guid} never carries an "id" field on a real registry -- only "guid".
         let _m2 = server
-            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .mock(
+                "GET",
+                "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001?deleted=true",
+            )
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
             .with_body(r#"{"schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
@@ -539,6 +547,74 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(decoded.value, value);
+    }
+
+    #[test]
+    fn guid_only_schemas_without_id_do_not_collide_on_fallback_url() {
+        // GET /schemas/guids/{guid} never returns an "id" (see get_schema_by_guid), so two
+        // different schemas resolved only by guid and lacking their own `$id` must not collide
+        // on the same fallback compile-scope url -- they used to, since both defaulted to the
+        // same "id/0.json" placeholder. See
+        // https://github.com/gklijs/schema_registry_converter/issues/139.
+        let mut server = mockito::Server::new();
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let mut decoder = JsonDecoder::new(sr_settings);
+
+        let schema_a = r#"{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"a\":{\"type\":\"string\"}},\"required\":[\"a\"]}"#;
+        let schema_b = r#"{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"b\":{\"type\":\"string\"}},\"required\":[\"b\"]}"#;
+        let guid_a = "cc0e0e0e-53c1-4a1a-8f1a-000000000001";
+        let guid_b = "dd0e0e0e-53c1-4a1a-8f1a-000000000002";
+
+        let _m1 = server
+            .mock(
+                "GET",
+                format!("/schemas/guids/{guid_a}?deleted=true").as_str(),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(format!(
+                r#"{{"guid":"{guid_a}","schema":"{schema_a}","schemaType":"JSON"}}"#
+            ))
+            .create();
+        let _m2 = server
+            .mock(
+                "GET",
+                format!("/schemas/guids/{guid_b}?deleted=true").as_str(),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(format!(
+                r#"{{"guid":"{guid_b}","schema":"{schema_b}","schemaType":"JSON"}}"#
+            ))
+            .create();
+
+        let header_a = build_schema_id_header(VALUE_SCHEMA_ID_HEADER, guid_a, &[]).unwrap();
+        let header_b = build_schema_id_header(VALUE_SCHEMA_ID_HEADER, guid_b, &[]).unwrap();
+        let value_a = serde_json::json!({"a": "x"});
+        let value_b = serde_json::json!({"b": "y"});
+        let bytes_a = serde_json::to_vec(&value_a).unwrap();
+        let bytes_b = serde_json::to_vec(&value_b).unwrap();
+
+        let decoded_a = decoder
+            .decode_with_header_id(Some(&header_a.value), Some(&bytes_a))
+            .unwrap()
+            .unwrap();
+        // Each message must validate against its own schema...
+        assert!(decoded_a.schema.validate(&value_a).is_strictly_valid());
+        // ...and fail against the other's, proving they're genuinely different compiled schemas
+        // rather than both resolving to whichever was compiled first.
+        assert!(!decoded_a.schema.validate(&value_b).is_strictly_valid());
+        drop(decoded_a);
+
+        let decoded_b = decoder
+            .decode_with_header_id(Some(&header_b.value), Some(&bytes_b))
+            .unwrap()
+            .unwrap();
+        assert!(decoded_b.schema.validate(&value_b).is_strictly_valid());
+        assert!(!decoded_b.schema.validate(&value_a).is_strictly_valid());
     }
 
     #[test]
@@ -902,6 +978,45 @@ mod tests {
     }
 
     #[test]
+    fn circular_reference_returns_error_instead_of_overflowing_stack() {
+        // A schema that (transitively) references itself must be rejected with a clean
+        // SRCError instead of recursing until the stack overflows. See
+        // https://github.com/gklijs/schema_registry_converter/issues/139.
+        let mut server = mockito::Server::new();
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let mut decoder = JsonDecoder::new(sr_settings);
+
+        let schema = r#"{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"self\":{\"$ref\":\"self.json\"}}}"#;
+        let reference = r#"{"name": "self.json", "subject": "circular", "version": 1}"#;
+
+        let _m = server
+            .mock("GET", "/schemas/ids/5?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_json_body_with_reference(schema, 5, reference))
+            .create();
+        // The reference resolves to the *same* self-referencing schema, so following it
+        // recurses into "self.json" again indefinitely.
+        let _m2 = server
+            .mock("GET", "/subjects/circular/versions/1")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_json_body_with_reference(schema, 5, reference))
+            .create();
+
+        let bytes = get_payload(5, br#"{"self":{}}"#.to_vec());
+        let error = decoder.decode(Some(&bytes)).unwrap_err();
+        assert!(
+            error.error.contains("reference chain exceeded"),
+            "expected a reference-depth error, got {:?}",
+            error
+        );
+    }
+
+    #[test]
     fn encounter_same_reference_again() {
         let mut server = mockito::Server::new();
         let sr_settings = SrSettings::new_builder(server.url())
@@ -1097,6 +1212,40 @@ mod tests {
         let result_example: Value = Value::String(String::from("Foo"));
 
         let error = encoder.encode(&result_example, &strategy).unwrap_err();
+
+        assert_eq!(
+            error.error,
+            String::from(
+                r#"Value "Foo" was not valid according to the schema because [WrongType { path: "", detail: "The value must be object" }]"#
+            )
+        )
+    }
+
+    #[test]
+    fn test_encode_with_header_id_not_valid() {
+        // encode_with_header_id must reject a non-conforming value just like encode() does,
+        // rather than skipping validation because it doesn't need the schema's numeric id.
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/subjects/testresult-value/versions/latest")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(
+                r#"{"subject":"testresult-value","version":1,"id":10,"guid":"cc0e0e0e-53c1-4a1a-8f1a-000000000001","schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#,
+            )
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let mut encoder = JsonEncoder::new(sr_settings);
+        let strategy = SubjectNameStrategy::TopicNameStrategy(String::from("testresult"), false);
+        let result_example: Value = Value::String(String::from("Foo"));
+
+        let error = encoder
+            .encode_with_header_id(&result_example, &strategy, false)
+            .unwrap_err();
 
         assert_eq!(
             error.error,

--- a/src/blocking/json.rs
+++ b/src/blocking/json.rs
@@ -8,13 +8,17 @@ use valico::json_schema::schema::ScopedSchema;
 use valico::json_schema::{Scope, ValidationState};
 
 use crate::blocking::schema_registry::{
-    get_referenced_schema, get_schema_by_id_and_type, get_schema_by_subject, SrSettings,
+    get_referenced_schema, get_schema_by_guid_and_type, get_schema_by_id_and_type,
+    get_schema_by_subject, SrSettings,
 };
 use crate::error::SRCError;
-use crate::json_common::{fetch_fallback, fetch_id, handle_validation, to_bytes, to_value};
+use crate::json_common::{
+    fetch_fallback, fetch_id, handle_validation, to_bytes, to_bytes_raw, to_value,
+};
 use crate::schema_registry_common::{
-    get_bytes_result, invalid_bytes_error, BytesResult, RegisteredReference, RegisteredSchema,
-    SchemaType, SubjectNameStrategy,
+    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    BytesResult, HeaderSchemaId, RegisteredReference, RegisteredSchema, SchemaIdHeader, SchemaType,
+    SubjectNameStrategy, KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
 };
 
 /// Encoder that works by prepending the correct bytes in order to make it valid schema registry
@@ -74,6 +78,7 @@ impl JsonEncoder {
                         Ok(url) => Ok(EncodeContext {
                             id: registered_schema.id,
                             url,
+                            guid: registered_schema.guid,
                         }),
                         Err(e) => Err(e),
                     },
@@ -98,18 +103,93 @@ impl JsonEncoder {
             Err(e) => Err(e.clone()),
         }
     }
+
+    /// Like [`JsonEncoder::encode`], but instead of prefixing the payload with the schema id
+    /// (the default confluent wire format), returns the raw JSON bytes alongside a
+    /// [`SchemaIdHeader`] carrying the schema's guid. Attach the header to the Kafka record
+    /// using whatever Kafka client you're using -- this crate has no dependency on one. `is_key`
+    /// picks between the `__key_schema_id`/`__value_schema_id` header names, matching
+    /// Confluent's `HeaderSchemaIdSerializer`. See
+    /// https://github.com/gklijs/schema_registry_converter/issues/139.
+    ///
+    /// Requires a schema registry that returns a `guid` (Confluent Schema Registry 8.0+); a
+    /// registry that doesn't will make this return an error.
+    pub fn encode_with_header_id(
+        &mut self,
+        value: &Value,
+        subject_name_strategy: &SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let cached_context = match self.cache.entry(key) {
+            Entry::Occupied(entry) => entry.into_mut().as_ref(),
+            Entry::Vacant(entry) => {
+                let result = match get_schema_by_subject(&self.sr_settings, subject_name_strategy) {
+                    Ok(registered_schema) => match set_scoped_schema(
+                        &mut self.scope,
+                        &self.sr_settings,
+                        &registered_schema,
+                    ) {
+                        Ok(url) => Ok(EncodeContext {
+                            id: registered_schema.id,
+                            url,
+                            guid: registered_schema.guid,
+                        }),
+                        Err(e) => Err(e),
+                    },
+                    Err(e) => Err(e),
+                };
+                match result {
+                    Err(e) if e.retriable => return Err(e),
+                    result => entry.insert(result.map_err(SRCError::into_cache)).as_ref(),
+                }
+            }
+        };
+        let context = match cached_context {
+            Ok(c) => c.clone(),
+            Err(e) => return Err(e.clone()),
+        };
+        if self.scope.resolve(&context.url).is_none() {
+            return Err(SRCError::non_retryable_without_cause(
+                "could not get schema from scope",
+            ));
+        }
+        let bytes = to_bytes_raw(value)?;
+        let header = schema_id_header_for(context.guid.as_deref(), is_key)?;
+        Ok((bytes, header))
+    }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct EncodeContext {
     id: u32,
     url: Url,
+    guid: Option<String>,
+}
+
+fn schema_id_header_for(guid: Option<&str>, is_key: bool) -> Result<SchemaIdHeader, SRCError> {
+    let guid = guid.ok_or_else(|| {
+        SRCError::non_retryable_without_cause(
+            "Schema registry response did not include a guid; encoding the schema id in a \
+             header requires Confluent Schema Registry 8.0+",
+        )
+    })?;
+    let name = if is_key {
+        KEY_SCHEMA_ID_HEADER
+    } else {
+        VALUE_SCHEMA_ID_HEADER
+    };
+    build_schema_id_header(name, guid, &[])
 }
 
 #[derive(Debug)]
 pub struct JsonDecoder {
     sr_settings: SrSettings,
     cache: HashMap<u32, Result<Url, SRCError>, RandomState>,
+    /// Cache for schemas looked up by guid rather than id, used by
+    /// [`JsonDecoder::decode_with_header_id`]. Kept separate from `cache` (keyed by id) since a
+    /// guid and an id are different keyspaces.
+    guid_cache: HashMap<String, Result<Url, SRCError>, RandomState>,
     scope: Scope,
 }
 
@@ -125,6 +205,7 @@ impl JsonDecoder {
         JsonDecoder {
             sr_settings,
             cache: HashMap::new(),
+            guid_cache: HashMap::new(),
             scope: Scope::new(),
         }
     }
@@ -134,6 +215,7 @@ impl JsonDecoder {
     /// stored in the cache in the first place, so there's nothing to remove for those.
     pub fn remove_errors_from_cache(&mut self) {
         self.cache.retain(|_, v| v.is_ok());
+        self.guid_cache.retain(|_, v| v.is_ok());
     }
     /// Reads the bytes to get the name, and gives back the data bytes.
     pub fn decode(&mut self, bytes: Option<&[u8]>) -> Result<Option<DecodeResult>, SRCError> {
@@ -143,6 +225,40 @@ impl JsonDecoder {
             BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(
                 &invalid_bytes_error(i),
             )),
+        }
+    }
+    /// Like [`JsonDecoder::decode`], but for a message that may carry its schema id/guid in a
+    /// `__key_schema_id`/`__value_schema_id` header instead of (or in addition to) the payload
+    /// prefix, mirroring Confluent's `DualSchemaIdDeserializer`: `header_value` present ->
+    /// resolve the schema from it and treat `bytes` as the raw (unprefixed) payload;
+    /// `header_value` absent -> falls straight through to [`JsonDecoder::decode`], so the only
+    /// overhead for a caller who always passes `None` is this one check. See
+    /// https://github.com/gklijs/schema_registry_converter/issues/139.
+    pub fn decode_with_header_id(
+        &mut self,
+        header_value: Option<&[u8]>,
+        bytes: Option<&[u8]>,
+    ) -> Result<Option<DecodeResult<'_>>, SRCError> {
+        let payload = match bytes {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+        match header_value {
+            None => self.decode(Some(payload)),
+            Some(header) => {
+                let (schema_id, _rest) = parse_schema_id_header(header)?;
+                let schema = match schema_id {
+                    HeaderSchemaId::Id(id) => self.schema(id)?,
+                    HeaderSchemaId::Guid(guid) => self.guid_schema(guid)?,
+                };
+                match serde_json::from_slice(payload) {
+                    Ok(value) => Ok(Some(DecodeResult { schema, value })),
+                    Err(e) => Err(SRCError::non_retryable_with_cause(
+                        e,
+                        "could not create value from bytes",
+                    )),
+                }
+            }
         }
     }
     /// The actual deserialization trying to get the id from the bytes to retrieve the schema, and
@@ -175,6 +291,37 @@ impl JsonDecoder {
                     // Retriable errors (transient network/HTTP issues) don't make sense to
                     // cache, so the entry is left vacant and the next call issues a fresh
                     // request rather than replaying a stale failure.
+                    Err(e) if e.retriable => return Err(e),
+                    result => &*entry.insert(result.map_err(SRCError::into_cache)),
+                }
+            }
+        };
+        match url {
+            Ok(id) => match self.scope.resolve(id) {
+                Some(schema) => Ok(schema),
+                None => Err(SRCError::non_retryable_without_cause(
+                    "could not get schema from scope",
+                )),
+            },
+            Err(e) => Err(e.clone()),
+        }
+    }
+
+    /// Like [`JsonDecoder::schema`], but looks the schema up by guid instead of id -- used by
+    /// [`JsonDecoder::decode_with_header_id`] when the header carries a guid rather than an id.
+    fn guid_schema(&mut self, guid: String) -> Result<ScopedSchema<'_>, SRCError> {
+        let url = match self.guid_cache.entry(guid.clone()) {
+            Entry::Occupied(entry) => &*entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let result =
+                    match get_schema_by_guid_and_type(&guid, &self.sr_settings, SchemaType::Json) {
+                        Ok(r) => match set_scoped_schema(&mut self.scope, &self.sr_settings, &r) {
+                            Ok(schema) => Ok(schema),
+                            Err(e) => Err(e),
+                        },
+                        Err(e) => Err(e),
+                    };
+                match result {
                     Err(e) if e.retriable => return Err(e),
                     result => &*entry.insert(result.map_err(SRCError::into_cache)),
                 }
@@ -236,6 +383,14 @@ fn set_scoped_schema(
         Some(url) => url,
         None => fetch_fallback(sr_settings.url(), registered_schema.id),
     };
+    // Same schema can now be reached through two independent caches -- by id (`schema`) and by
+    // guid (`guid_schema`) -- sharing this one `scope`. If it's already compiled under this url
+    // (e.g. looked up by id first, now by guid, or vice versa) reuse that rather than trying to
+    // `compile_with_id` a second time, which `valico` rejects as an id conflict. See
+    // https://github.com/gklijs/schema_registry_converter/issues/139.
+    if scope.resolve(&id).is_some() {
+        return Ok(id);
+    }
     match scope.compile_with_id(&id, def, false) {
         Ok(_) => (),
         Err(e) => {
@@ -264,7 +419,7 @@ mod tests {
     use crate::blocking::json::{JsonDecoder, JsonEncoder};
     use crate::blocking::schema_registry::SrSettings;
     use crate::json_common::handle_validation;
-    use crate::schema_registry_common::{get_payload, SubjectNameStrategy};
+    use crate::schema_registry_common::{get_payload, SubjectNameStrategy, VALUE_SCHEMA_ID_HEADER};
     use test_utils::{
         get_json_body, get_json_body_with_reference, json_extra_schema, json_get_extra_references,
         json_get_result_references, json_incorrect_bytes, json_result_java_bytes,
@@ -314,6 +469,67 @@ mod tests {
         let encoded_data = encoder.encode(&result_example, &strategy).unwrap();
 
         assert_eq!(encoded_data, json_result_java_bytes())
+    }
+
+    #[test]
+    fn test_encode_and_decode_with_header_id() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/subjects/testresult-value/versions/latest")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"subject":"testresult-value","version":1,"id":10,"guid":"cc0e0e0e-53c1-4a1a-8f1a-000000000001","schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let mut encoder = JsonEncoder::new(sr_settings.clone());
+        let strategy = SubjectNameStrategy::TopicNameStrategy(String::from("testresult"), false);
+        let value: Value = serde_json::json!({"foo": "bar"});
+
+        let (bytes, header) = encoder
+            .encode_with_header_id(&value, &strategy, false)
+            .unwrap();
+
+        assert_eq!(bytes, serde_json::to_vec(&value).unwrap());
+        assert_eq!(header.name, VALUE_SCHEMA_ID_HEADER);
+        assert_eq!(
+            header.value,
+            vec![
+                0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x01,
+            ]
+        );
+
+        let _m2 = server
+            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"id":10,"schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
+            .create();
+
+        let mut decoder = JsonDecoder::new(sr_settings);
+        let decoded = decoder
+            .decode_with_header_id(Some(&header.value), Some(&bytes))
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.value, value);
+
+        // header absent -> falls straight through to decode(), which expects the prefix
+        let _m3 = server
+            .mock("GET", "/schemas/ids/10?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"id":10,"schema":"{\"type\":\"object\"}","schemaType":"JSON"}"#)
+            .create();
+        let prefixed = get_payload(10, serde_json::to_vec(&value).unwrap());
+        let decoded = decoder
+            .decode_with_header_id(None, Some(&prefixed))
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.value, value);
     }
 
     #[test]
@@ -808,7 +1024,7 @@ mod tests {
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
         let decoder = JsonDecoder::new(sr_settings);
         assert!(
-                   format!("{:?}", decoder).starts_with("JsonDecoder { sr_settings: SrSettings { urls: [\"http://127.0.0.1:1234\"], client: Client, authorization: None }, cache: {}, scope: Scope {")
+                   format!("{:?}", decoder).starts_with("JsonDecoder { sr_settings: SrSettings { urls: [\"http://127.0.0.1:1234\"], client: Client, authorization: None }, cache: {}, guid_cache: {}, scope: Scope {")
         )
     }
 

--- a/src/blocking/proto_decoder.rs
+++ b/src/blocking/proto_decoder.rs
@@ -14,8 +14,25 @@ use crate::schema_registry_common::{
     get_bytes_result, parse_schema_id_header, BytesResult, HeaderSchemaId, RegisteredSchema,
     SchemaType,
 };
-use protofish::context::Context;
+use protofish::context::{Context, MessageInfo};
 use protofish::decode::{MessageValue, Value};
+
+/// `Context::get_message` returns `None` for a name it can't resolve. Surfacing that as an
+/// `SRCError` instead of panicking matters most for `decode_with_header_id`, where `full_name`
+/// is ultimately derived from Kafka header bytes a producer controls (a guid paired with a
+/// message index that doesn't actually match anything in the resolved schema), rather than from
+/// data `resolve_name` has already validated against this same context.
+fn get_message_info<'a>(
+    context: &'a Context,
+    full_name: &str,
+) -> Result<&'a MessageInfo, SRCError> {
+    context.get_message(full_name).ok_or_else(|| {
+        SRCError::non_retryable_without_cause(&format!(
+            "could not find message {} in the resolved protobuf schema",
+            full_name
+        ))
+    })
+}
 
 #[derive(Debug)]
 pub struct ProtoDecoder {
@@ -90,7 +107,7 @@ impl ProtoDecoder {
                 };
                 let (index, _empty) = to_index_and_data(index_bytes)?;
                 let full_name = resolve_name(&context.resolver, &index)?;
-                let message_info = context.context.get_message(&full_name).unwrap();
+                let message_info = get_message_info(&context.context, &full_name)?;
                 Ok(Value::Message(Box::from(
                     message_info.decode(payload, &context.context),
                 )))
@@ -104,7 +121,7 @@ impl ProtoDecoder {
             Ok(s) => {
                 let (index, data) = to_index_and_data(bytes)?;
                 let full_name = resolve_name(&s.resolver, &index)?;
-                let message_info = s.context.get_message(&full_name).unwrap();
+                let message_info = get_message_info(&s.context, &full_name)?;
                 Ok(message_info.decode(&data, &s.context))
             }
             Err(e) => Err(e),
@@ -141,7 +158,7 @@ impl ProtoDecoder {
             Ok(s) => {
                 let (index, data_bytes) = to_index_and_data(bytes)?;
                 let full_name = resolve_name(&s.resolver, &index)?;
-                let message_info = s.context.get_message(&full_name).unwrap();
+                let message_info = get_message_info(&s.context, &full_name)?;
                 let value = message_info.decode(&data_bytes, &s.context);
                 Ok(DecodeResultWithContext {
                     value,
@@ -268,8 +285,11 @@ fn to_resolve_context(
 
 #[cfg(test)]
 mod tests {
-    use crate::blocking::proto_decoder::ProtoDecoder;
+    use std::collections::HashSet;
+
+    use crate::blocking::proto_decoder::{get_message_info, ProtoDecoder};
     use crate::blocking::schema_registry::SrSettings;
+    use protofish::context::Context;
     use protofish::decode::Value;
     use test_utils::{
         get_proto_body, get_proto_body_with_reference, get_proto_complex,
@@ -309,7 +329,10 @@ mod tests {
     fn test_decode_with_header_id() {
         let mut server = mockito::Server::new();
         let _m = server
-            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .mock(
+                "GET",
+                "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001?deleted=true",
+            )
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
             .with_body(get_proto_body(get_proto_hb_schema(), 1))
@@ -351,6 +374,25 @@ mod tests {
             v => panic!("Other value: {:?} than expected Message", v),
         };
         assert_eq!(Value::UInt64(101u64), message.fields[0].value);
+    }
+
+    #[test]
+    fn get_message_info_returns_error_instead_of_panicking_for_unknown_message() {
+        // Context::get_message returns None for a name it can't resolve -- e.g. from a header
+        // whose guid/message-index resolves to a message this schema doesn't actually contain.
+        // That must come back as an SRCError, not panic the caller. See
+        // https://github.com/gklijs/schema_registry_converter/issues/139.
+        let schema =
+            "syntax = \"proto3\"; package nl.openweb.data; message Heartbeat { uint64 beat = 1; }";
+        let mut files = HashSet::new();
+        files.insert(schema.to_string());
+        let context = Context::parse(&files).unwrap();
+
+        let err = get_message_info(&context, "nl.openweb.data.DoesNotExist").unwrap_err();
+        assert_eq!(
+            err.error,
+            "could not find message nl.openweb.data.DoesNotExist in the resolved protobuf schema"
+        );
     }
 
     #[test]

--- a/src/blocking/proto_decoder.rs
+++ b/src/blocking/proto_decoder.rs
@@ -5,12 +5,15 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::blocking::schema_registry::{
-    get_referenced_schema, get_schema_by_id_and_type, SrSettings,
+    get_referenced_schema, get_schema_by_guid_and_type, get_schema_by_id_and_type, SrSettings,
 };
 use crate::error::SRCError;
 use crate::proto_common_types::add_common_files;
 use crate::proto_resolver::{resolve_name, to_index_and_data, MessageResolver};
-use crate::schema_registry_common::{get_bytes_result, BytesResult, RegisteredSchema, SchemaType};
+use crate::schema_registry_common::{
+    get_bytes_result, parse_schema_id_header, BytesResult, HeaderSchemaId, RegisteredSchema,
+    SchemaType,
+};
 use protofish::context::Context;
 use protofish::decode::{MessageValue, Value};
 
@@ -18,6 +21,10 @@ use protofish::decode::{MessageValue, Value};
 pub struct ProtoDecoder {
     sr_settings: SrSettings,
     cache: DashMap<u32, Result<Arc<DecodeContext>, SRCError>>,
+    /// Cache for schemas looked up by guid rather than id, used by
+    /// [`ProtoDecoder::decode_with_header_id`]. Kept separate from `cache` (keyed by id) since
+    /// a guid and an id are different keyspaces.
+    guid_cache: DashMap<String, Result<Arc<DecodeContext>, SRCError>>,
 }
 
 impl ProtoDecoder {
@@ -32,6 +39,7 @@ impl ProtoDecoder {
         ProtoDecoder {
             sr_settings,
             cache: DashMap::new(),
+            guid_cache: DashMap::new(),
         }
     }
     /// Removes all non-retriable errors from the cache. You might need/want to run this when the
@@ -40,6 +48,7 @@ impl ProtoDecoder {
     /// stored in the cache in the first place, so there's nothing to remove for those.
     pub fn remove_errors_from_cache(&self) {
         self.cache.retain(|_, v| v.is_ok());
+        self.guid_cache.retain(|_, v| v.is_ok());
     }
     /// Decodes bytes into a value.
     /// The choice to use Option<&[u8]> as type us made so it plays nice with the BorrowedMessage
@@ -53,6 +62,39 @@ impl ProtoDecoder {
                 Ok(Value::Message(Box::from(self.deserialize(id, bytes)?)))
             }
             BytesResult::Invalid(i) => Ok(Value::Bytes(Bytes::copy_from_slice(i))),
+        }
+    }
+    /// Like [`ProtoDecoder::decode`], but for a message that may carry its schema id/guid and
+    /// message index in a `__key_schema_id`/`__value_schema_id` header instead of (or in
+    /// addition to) the payload prefix, mirroring Confluent's `DualSchemaIdDeserializer`:
+    /// `header_value` present -> resolve the schema and message index from it and treat `bytes`
+    /// as the raw (unprefixed) payload; `header_value` absent -> falls straight through to
+    /// [`ProtoDecoder::decode`], so the only overhead for a caller who always passes `None` is
+    /// this one check. See https://github.com/gklijs/schema_registry_converter/issues/139.
+    pub fn decode_with_header_id(
+        &self,
+        header_value: Option<&[u8]>,
+        bytes: Option<&[u8]>,
+    ) -> Result<Value, SRCError> {
+        let payload = match bytes {
+            Some(v) => v,
+            None => return Ok(Value::Bytes(Bytes::new())),
+        };
+        match header_value {
+            None => self.decode(Some(payload)),
+            Some(header) => {
+                let (schema_id, index_bytes) = parse_schema_id_header(header)?;
+                let context = match schema_id {
+                    HeaderSchemaId::Id(id) => self.context(id)?,
+                    HeaderSchemaId::Guid(guid) => self.guid_context(guid)?,
+                };
+                let (index, _empty) = to_index_and_data(index_bytes)?;
+                let full_name = resolve_name(&context.resolver, &index)?;
+                let message_info = context.context.get_message(&full_name).unwrap();
+                Ok(Value::Message(Box::from(
+                    message_info.decode(payload, &context.context),
+                )))
+            }
         }
     }
     /// The actual deserialization trying to get the id from the bytes to retrieve the schema, and
@@ -129,6 +171,31 @@ impl ProtoDecoder {
                     // e.g. a parse failure, are cached permanently. Unlike the async decoder,
                     // this caches the fully-parsed Context rather than re-parsing on every
                     // decode call — see https://github.com/gklijs/schema_registry_converter/issues/175.
+                    Err(e) if e.retriable => Err(e),
+                    result => entry
+                        .insert(result.map_err(SRCError::into_cache))
+                        .value()
+                        .clone(),
+                }
+            }
+        }
+    }
+
+    /// Like [`ProtoDecoder::context`], but looks the schema up by guid instead of id -- used by
+    /// [`ProtoDecoder::decode_with_header_id`] when the header carries a guid rather than an id.
+    fn guid_context(&self, guid: String) -> Result<Arc<DecodeContext>, SRCError> {
+        match self.guid_cache.entry(guid.clone()) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let result = match get_schema_by_guid_and_type(
+                    &guid,
+                    &self.sr_settings,
+                    SchemaType::Protobuf,
+                ) {
+                    Ok(v) => to_resolve_context(&self.sr_settings, v),
+                    Err(e) => Err(e),
+                };
+                match result {
                     Err(e) if e.retriable => Err(e),
                     result => entry
                         .insert(result.map_err(SRCError::into_cache))
@@ -236,6 +303,54 @@ mod tests {
         };
 
         assert_eq!(Value::UInt64(101u64), message.fields[0].value)
+    }
+
+    #[test]
+    fn test_decode_with_header_id() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = ProtoDecoder::new(sr_settings);
+        // magic byte 0x01 + 16-byte guid + single-message index byte 0x00
+        let header_value = [
+            0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x01, 0x00,
+        ];
+        let payload = &get_proto_hb_101()[6..]; // data only, no prefix/index
+
+        let heartbeat = decoder
+            .decode_with_header_id(Some(&header_value), Some(payload))
+            .unwrap();
+        let message = match heartbeat {
+            Value::Message(x) => *x,
+            v => panic!("Other value: {:?} than expected Message", v),
+        };
+        assert_eq!(Value::UInt64(101u64), message.fields[0].value);
+
+        // header absent -> falls straight through to decode(), which expects the prefix
+        let _m2 = server
+            .mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 1))
+            .create();
+        let heartbeat = decoder
+            .decode_with_header_id(None, Some(get_proto_hb_101()))
+            .unwrap();
+        let message = match heartbeat {
+            Value::Message(x) => *x,
+            v => panic!("Other value: {:?} than expected Message", v),
+        };
+        assert_eq!(Value::UInt64(101u64), message.fields[0].value);
     }
 
     #[test]
@@ -400,7 +515,7 @@ mod tests {
         let sr_settings = SrSettings::new("http://127.0.0.1:1234".to_string());
         let decoder = ProtoDecoder::new(sr_settings);
         assert_eq!(
-            "ProtoDecoder { sr_settings: SrSettings { urls: [\"http://127.0.0.1:1234\"], client: Client, authorization: None }, cache: {} }"
+            "ProtoDecoder { sr_settings: SrSettings { urls: [\"http://127.0.0.1:1234\"], client: Client, authorization: None }, cache: {}, guid_cache: {} }"
                 .to_owned(),
             format!("{:?}", decoder)
         )

--- a/src/blocking/proto_raw.rs
+++ b/src/blocking/proto_raw.rs
@@ -12,9 +12,8 @@ use crate::proto_raw_common::{
 };
 use crate::proto_resolver::{resolve_name, to_index_and_data, IndexResolver};
 use crate::schema_registry_common::{
-    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    get_bytes_result, invalid_bytes_error, parse_schema_id_header, schema_id_header_for,
     BytesResult, HeaderSchemaId, RegisteredSchema, SchemaIdHeader, SchemaType, SubjectNameStrategy,
-    KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
 };
 
 /// Encoder that works by prepending the correct bytes in order to make it valid schema registry
@@ -74,7 +73,7 @@ impl ProtoRawEncoder {
         let key = subject_name_strategy.get_subject()?;
         let encode_context = self.encoding_context(key, subject_name_strategy)?;
         let index = index_bytes(&encode_context, full_name)?;
-        let header = schema_id_header_for(&encode_context, &index, is_key)?;
+        let header = schema_id_header_for(encode_context.guid.as_deref(), is_key, &index)?;
         Ok((bytes.to_vec(), header))
     }
 
@@ -102,7 +101,7 @@ impl ProtoRawEncoder {
         let key = subject_name_strategy.get_subject()?;
         let encode_context = self.encoding_context(key, subject_name_strategy)?;
         let index = index_bytes_single_message(&encode_context)?;
-        let header = schema_id_header_for(&encode_context, &index, is_key)?;
+        let header = schema_id_header_for(encode_context.guid.as_deref(), is_key, &index)?;
         Ok((bytes.to_vec(), header))
     }
 
@@ -126,28 +125,6 @@ impl ProtoRawEncoder {
             }
         }
     }
-}
-
-/// Builds the [`SchemaIdHeader`] for `encode_context`, requiring it to carry a guid (populated
-/// when the schema registry response included one, i.e. Confluent Schema Registry 8.0+),
-/// appending `index` (the message index, unlike Avro/JSON which have none) after the guid.
-fn schema_id_header_for(
-    encode_context: &EncodeContext,
-    index: &[u8],
-    is_key: bool,
-) -> Result<SchemaIdHeader, SRCError> {
-    let guid = encode_context.guid.as_deref().ok_or_else(|| {
-        SRCError::non_retryable_without_cause(
-            "Schema registry response did not include a guid; encoding the schema id in a \
-             header requires Confluent Schema Registry 8.0+",
-        )
-    })?;
-    let name = if is_key {
-        KEY_SCHEMA_ID_HEADER
-    } else {
-        VALUE_SCHEMA_ID_HEADER
-    };
-    build_schema_id_header(name, guid, index)
 }
 
 #[derive(Debug)]
@@ -245,14 +222,23 @@ impl ProtoRawDecoder {
     /// it into the cache.
     fn context(&self, id: u32) -> Result<Arc<DecodeContext>, SRCError> {
         match self.cache.entry(id) {
-            Entry::Occupied(e) => e.get().clone(),
-            Entry::Vacant(e) => {
-                let v = match get_schema_by_id_and_type(id, &self.sr_settings, SchemaType::Protobuf)
-                {
-                    Ok(r) => Ok(Arc::new(to_decode_context(r))),
-                    Err(e) => Err(e.into_cache()),
-                };
-                e.insert(v).value().clone()
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let result =
+                    match get_schema_by_id_and_type(id, &self.sr_settings, SchemaType::Protobuf) {
+                        Ok(r) => Ok(Arc::new(to_decode_context(r))),
+                        Err(e) => Err(e),
+                    };
+                match result {
+                    // Retriable errors (transient network/HTTP issues) don't make sense to
+                    // cache, so the entry is left vacant and the next call issues a fresh
+                    // request rather than replaying a stale failure.
+                    Err(e) if e.retriable => Err(e),
+                    result => entry
+                        .insert(result.map_err(SRCError::into_cache))
+                        .value()
+                        .clone(),
+                }
             }
         }
     }
@@ -262,17 +248,23 @@ impl ProtoRawDecoder {
     /// an id.
     fn context_by_guid(&self, guid: String) -> Result<Arc<DecodeContext>, SRCError> {
         match self.guid_cache.entry(guid.clone()) {
-            Entry::Occupied(e) => e.get().clone(),
-            Entry::Vacant(e) => {
-                let v = match get_schema_by_guid_and_type(
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let result = match get_schema_by_guid_and_type(
                     &guid,
                     &self.sr_settings,
                     SchemaType::Protobuf,
                 ) {
                     Ok(r) => Ok(Arc::new(to_decode_context(r))),
-                    Err(e) => Err(e.into_cache()),
+                    Err(e) => Err(e),
                 };
-                e.insert(v).value().clone()
+                match result {
+                    Err(e) if e.retriable => Err(e),
+                    result => entry
+                        .insert(result.map_err(SRCError::into_cache))
+                        .value()
+                        .clone(),
+                }
             }
         }
     }
@@ -290,7 +282,8 @@ mod tests {
     use crate::blocking::proto_raw::{ProtoRawDecoder, ProtoRawEncoder};
     use crate::blocking::schema_registry::SrSettings;
     use crate::schema_registry_common::{
-        SchemaType, SubjectNameStrategy, SuppliedReference, SuppliedSchema, VALUE_SCHEMA_ID_HEADER,
+        build_schema_id_header, SchemaType, SubjectNameStrategy, SuppliedReference, SuppliedSchema,
+        VALUE_SCHEMA_ID_HEADER,
     };
     use test_utils::{
         get_proto_body, get_proto_body_with_reference, get_proto_complex,
@@ -340,7 +333,10 @@ mod tests {
         );
 
         let _m2 = server
-            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .mock(
+                "GET",
+                "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001?deleted=true",
+            )
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
             .with_body(get_proto_body(get_proto_hb_schema(), 7))
@@ -363,6 +359,59 @@ mod tests {
             .create();
         let decoded = decoder
             .decode_with_header_id(None, Some(get_proto_hb_101()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.bytes, get_proto_hb_101_only_data());
+    }
+
+    #[test]
+    fn test_decode_with_header_id_guid_retriable_error_is_not_cached() {
+        // Regression test: a retriable error (e.g. a transient 503) resolving a schema by guid
+        // must not stick around in the cache, so the very next call succeeds without needing
+        // remove_errors_from_cache(). See https://github.com/gklijs/schema_registry_converter/issues/139.
+        let mut server = mockito::Server::new();
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let decoder = ProtoRawDecoder::new(sr_settings);
+        let guid = "cc0e0e0e-53c1-4a1a-8f1a-000000000001";
+        let header = build_schema_id_header(VALUE_SCHEMA_ID_HEADER, guid, &[0x00]).unwrap();
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/schemas/guids/{guid}?deleted=true").as_str(),
+            )
+            .with_status(503)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"error_code":50302,"message":"Leader not known"}"#)
+            .create();
+
+        let err = decoder
+            .decode_with_header_id(Some(&header.value), Some(get_proto_hb_101_only_data()))
+            .unwrap_err();
+        assert!(err.retriable, "expected a retriable error, got {:?}", err);
+        assert!(
+            !err.cached,
+            "retriable error should not be cached, got {:?}",
+            err
+        );
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/schemas/guids/{guid}?deleted=true").as_str(),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+
+        // No remove_errors_from_cache() call: this must succeed purely because the retriable
+        // error above was never cached in the first place.
+        let decoded = decoder
+            .decode_with_header_id(Some(&header.value), Some(get_proto_hb_101_only_data()))
             .unwrap()
             .unwrap();
         assert_eq!(decoded.bytes, get_proto_hb_101_only_data());

--- a/src/blocking/proto_raw.rs
+++ b/src/blocking/proto_raw.rs
@@ -3,16 +3,18 @@ use dashmap::DashMap;
 use std::sync::Arc;
 
 use crate::blocking::schema_registry::{
-    get_schema_by_id_and_type, get_schema_by_subject, SrSettings,
+    get_schema_by_guid_and_type, get_schema_by_id_and_type, get_schema_by_subject, SrSettings,
 };
 use crate::error::SRCError;
 use crate::proto_raw_common::{
-    to_bytes, to_bytes_single_message, to_decode_context, DecodeContext, EncodeContext,
+    index_bytes, index_bytes_single_message, to_bytes, to_bytes_single_message, to_decode_context,
+    DecodeContext, EncodeContext,
 };
 use crate::proto_resolver::{resolve_name, to_index_and_data, IndexResolver};
 use crate::schema_registry_common::{
-    get_bytes_result, invalid_bytes_error, BytesResult, RegisteredSchema, SchemaType,
-    SubjectNameStrategy,
+    build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+    BytesResult, HeaderSchemaId, RegisteredSchema, SchemaIdHeader, SchemaType, SubjectNameStrategy,
+    KEY_SCHEMA_ID_HEADER, VALUE_SCHEMA_ID_HEADER,
 };
 
 /// Encoder that works by prepending the correct bytes in order to make it valid schema registry
@@ -52,6 +54,30 @@ impl ProtoRawEncoder {
         }
     }
 
+    /// Like [`ProtoRawEncoder::encode`], but instead of prefixing the payload with the schema id
+    /// (the default confluent wire format), returns the raw protobuf bytes alongside a
+    /// [`SchemaIdHeader`] carrying the schema's guid and the message index. Attach the header to
+    /// the Kafka record using whatever Kafka client you're using -- this crate has no dependency
+    /// on one. `is_key` picks between the `__key_schema_id`/`__value_schema_id` header names,
+    /// matching Confluent's `HeaderSchemaIdSerializer`. See
+    /// https://github.com/gklijs/schema_registry_converter/issues/139.
+    ///
+    /// Requires a schema registry that returns a `guid` (Confluent Schema Registry 8.0+); a
+    /// registry that doesn't will make this return an error.
+    pub fn encode_with_header_id(
+        &self,
+        bytes: &[u8],
+        full_name: &str,
+        subject_name_strategy: &SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let encode_context = self.encoding_context(key, subject_name_strategy)?;
+        let index = index_bytes(&encode_context, full_name)?;
+        let header = schema_id_header_for(&encode_context, &index, is_key)?;
+        Ok((bytes.to_vec(), header))
+    }
+
     pub fn encode_single_message(
         &self,
         bytes: &[u8],
@@ -62,6 +88,22 @@ impl ProtoRawEncoder {
             Ok(encode_context) => to_bytes_single_message(&encode_context, bytes),
             Err(e) => Err(e),
         }
+    }
+
+    /// Like [`ProtoRawEncoder::encode_single_message`], but returns the schema id/guid as a
+    /// [`SchemaIdHeader`] instead of prefixing the payload with it. See
+    /// [`ProtoRawEncoder::encode_with_header_id`].
+    pub fn encode_single_message_with_header_id(
+        &self,
+        bytes: &[u8],
+        subject_name_strategy: &SubjectNameStrategy,
+        is_key: bool,
+    ) -> Result<(Vec<u8>, SchemaIdHeader), SRCError> {
+        let key = subject_name_strategy.get_subject()?;
+        let encode_context = self.encoding_context(key, subject_name_strategy)?;
+        let index = index_bytes_single_message(&encode_context)?;
+        let header = schema_id_header_for(&encode_context, &index, is_key)?;
+        Ok((bytes.to_vec(), header))
     }
 
     fn encoding_context(
@@ -75,6 +117,7 @@ impl ProtoRawEncoder {
                 let v = match get_schema_by_subject(&self.sr_settings, subject_name_strategy) {
                     Ok(registered_schema) => Ok(Arc::new(EncodeContext {
                         id: registered_schema.id,
+                        guid: registered_schema.guid,
                         resolver: IndexResolver::new(&registered_schema.schema),
                     })),
                     Err(e) => Err(e.into_cache()),
@@ -85,10 +128,36 @@ impl ProtoRawEncoder {
     }
 }
 
+/// Builds the [`SchemaIdHeader`] for `encode_context`, requiring it to carry a guid (populated
+/// when the schema registry response included one, i.e. Confluent Schema Registry 8.0+),
+/// appending `index` (the message index, unlike Avro/JSON which have none) after the guid.
+fn schema_id_header_for(
+    encode_context: &EncodeContext,
+    index: &[u8],
+    is_key: bool,
+) -> Result<SchemaIdHeader, SRCError> {
+    let guid = encode_context.guid.as_deref().ok_or_else(|| {
+        SRCError::non_retryable_without_cause(
+            "Schema registry response did not include a guid; encoding the schema id in a \
+             header requires Confluent Schema Registry 8.0+",
+        )
+    })?;
+    let name = if is_key {
+        KEY_SCHEMA_ID_HEADER
+    } else {
+        VALUE_SCHEMA_ID_HEADER
+    };
+    build_schema_id_header(name, guid, index)
+}
+
 #[derive(Debug)]
 pub struct ProtoRawDecoder {
     sr_settings: SrSettings,
     cache: DashMap<u32, Result<Arc<DecodeContext>, SRCError>>,
+    /// Cache for schemas looked up by guid rather than id, used by
+    /// [`ProtoRawDecoder::decode_with_header_id`]. Kept separate from `cache` (keyed by id)
+    /// since a guid and an id are different keyspaces.
+    guid_cache: DashMap<String, Result<Arc<DecodeContext>, SRCError>>,
 }
 
 impl ProtoRawDecoder {
@@ -101,6 +170,7 @@ impl ProtoRawDecoder {
         ProtoRawDecoder {
             sr_settings,
             cache: DashMap::new(),
+            guid_cache: DashMap::new(),
         }
     }
     /// Remove al the errors from the cache, you might need to/want to run this when a recoverable
@@ -108,6 +178,7 @@ impl ProtoRawDecoder {
     /// exist or can't be parsed.
     pub fn remove_errors_from_cache(&self) {
         self.cache.retain(|_, v| v.is_ok());
+        self.guid_cache.retain(|_, v| v.is_ok());
     }
     /// Reads the bytes to get the name, and gives back the data bytes.
     pub fn decode(&self, bytes: Option<&[u8]>) -> Result<Option<RawDecodeResult>, SRCError> {
@@ -117,6 +188,40 @@ impl ProtoRawDecoder {
             BytesResult::Invalid(i) => Err(SRCError::non_retryable_without_cause(
                 &invalid_bytes_error(i),
             )),
+        }
+    }
+    /// Like [`ProtoRawDecoder::decode`], but for a message that may carry its schema id/guid and
+    /// message index in a `__key_schema_id`/`__value_schema_id` header instead of (or in
+    /// addition to) the payload prefix, mirroring Confluent's `DualSchemaIdDeserializer`:
+    /// `header_value` present -> resolve the schema and message index from it and treat `bytes`
+    /// as the raw (unprefixed) payload; `header_value` absent -> falls straight through to
+    /// [`ProtoRawDecoder::decode`], so the only overhead for a caller who always passes `None`
+    /// is this one check. See https://github.com/gklijs/schema_registry_converter/issues/139.
+    pub fn decode_with_header_id(
+        &self,
+        header_value: Option<&[u8]>,
+        bytes: Option<&[u8]>,
+    ) -> Result<Option<RawDecodeResult>, SRCError> {
+        let payload = match bytes {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+        match header_value {
+            None => self.decode(Some(payload)),
+            Some(header) => {
+                let (schema_id, index_bytes) = parse_schema_id_header(header)?;
+                let context = match schema_id {
+                    HeaderSchemaId::Id(id) => self.context(id)?,
+                    HeaderSchemaId::Guid(guid) => self.context_by_guid(guid)?,
+                };
+                let (index, _empty) = to_index_and_data(index_bytes)?;
+                let full_name = resolve_name(&context.resolver, &index)?;
+                Ok(Some(RawDecodeResult {
+                    schema: context.schema.clone(),
+                    full_name,
+                    bytes: payload.to_vec(),
+                }))
+            }
         }
     }
     /// The actual deserialization trying to get the id from the bytes to retrieve the schema, and
@@ -151,6 +256,26 @@ impl ProtoRawDecoder {
             }
         }
     }
+
+    /// Like [`ProtoRawDecoder::context`], but looks the schema up by guid instead of id -- used
+    /// by [`ProtoRawDecoder::decode_with_header_id`] when the header carries a guid rather than
+    /// an id.
+    fn context_by_guid(&self, guid: String) -> Result<Arc<DecodeContext>, SRCError> {
+        match self.guid_cache.entry(guid.clone()) {
+            Entry::Occupied(e) => e.get().clone(),
+            Entry::Vacant(e) => {
+                let v = match get_schema_by_guid_and_type(
+                    &guid,
+                    &self.sr_settings,
+                    SchemaType::Protobuf,
+                ) {
+                    Ok(r) => Ok(Arc::new(to_decode_context(r))),
+                    Err(e) => Err(e.into_cache()),
+                };
+                e.insert(v).value().clone()
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -165,7 +290,7 @@ mod tests {
     use crate::blocking::proto_raw::{ProtoRawDecoder, ProtoRawEncoder};
     use crate::blocking::schema_registry::SrSettings;
     use crate::schema_registry_common::{
-        SchemaType, SubjectNameStrategy, SuppliedReference, SuppliedSchema,
+        SchemaType, SubjectNameStrategy, SuppliedReference, SuppliedSchema, VALUE_SCHEMA_ID_HEADER,
     };
     use test_utils::{
         get_proto_body, get_proto_body_with_reference, get_proto_complex,
@@ -173,6 +298,75 @@ mod tests {
         get_proto_complex_references, get_proto_hb_101, get_proto_hb_101_empty_payload,
         get_proto_hb_101_only_data, get_proto_hb_schema, get_proto_result,
     };
+
+    #[test]
+    fn test_encode_and_decode_with_header_id() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/subjects/nl.openweb.data.Heartbeat/versions/latest")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(format!(
+                "{{\"schema\":\"{}\", \"schemaType\":\"PROTOBUF\", \"id\":7, \"guid\":\"cc0e0e0e-53c1-4a1a-8f1a-000000000001\"}}",
+                get_proto_hb_schema()
+            ))
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let encoder = ProtoRawEncoder::new(sr_settings.clone());
+        let strategy =
+            SubjectNameStrategy::RecordNameStrategy(String::from("nl.openweb.data.Heartbeat"));
+
+        let (bytes, header) = encoder
+            .encode_with_header_id(
+                get_proto_hb_101_only_data(),
+                "nl.openweb.data.Heartbeat",
+                &strategy,
+                false,
+            )
+            .unwrap();
+
+        assert_eq!(bytes, get_proto_hb_101_only_data());
+        assert_eq!(header.name, VALUE_SCHEMA_ID_HEADER);
+        assert_eq!(
+            header.value,
+            vec![
+                0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x01, 0x00,
+            ]
+        );
+
+        let _m2 = server
+            .mock("GET", "/schemas/guids/cc0e0e0e-53c1-4a1a-8f1a-000000000001")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+
+        let decoder = ProtoRawDecoder::new(sr_settings);
+        let decoded = decoder
+            .decode_with_header_id(Some(&header.value), Some(&bytes))
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.bytes, get_proto_hb_101_only_data());
+        assert_eq!(*decoded.full_name, "nl.openweb.data.Heartbeat");
+
+        // header absent -> falls straight through to decode(), which expects the prefix
+        let _m3 = server
+            .mock("GET", "/schemas/ids/7?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(get_proto_body(get_proto_hb_schema(), 7))
+            .create();
+        let decoded = decoder
+            .decode_with_header_id(None, Some(get_proto_hb_101()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.bytes, get_proto_hb_101_only_data());
+    }
 
     #[test]
     fn test_encode_default() {
@@ -487,7 +681,7 @@ mod tests {
         let sr_settings = SrSettings::new(String::from("http://127.0.0.1:1234"));
         let decoder = ProtoRawDecoder::new(sr_settings);
         assert_eq!(
-            "ProtoRawDecoder { sr_settings: SrSettings { urls: [\"http://127.0.0.1:1234\"], client: Client, authorization: None }, cache: {} }"
+            "ProtoRawDecoder { sr_settings: SrSettings { urls: [\"http://127.0.0.1:1234\"], client: Client, authorization: None }, cache: {}, guid_cache: {} }"
                 .to_owned(),
             format!("{:?}", decoder)
         )

--- a/src/blocking/schema_registry.rs
+++ b/src/blocking/schema_registry.rs
@@ -221,6 +221,32 @@ pub fn get_schema_by_id_and_type(
     }
 }
 
+/// Gets a schema by its guid. This is used to get the correct schema to deserialize bytes when
+/// the guid is carried in a Kafka header rather than the payload prefix. See
+/// https://github.com/gklijs/schema_registry_converter/issues/139.
+pub fn get_schema_by_guid(
+    guid: &str,
+    sr_settings: &SrSettings,
+) -> Result<RegisteredSchema, SRCError> {
+    let raw_schema = perform_sr_call(sr_settings, SrCall::GetByGuid(guid))?;
+    raw_to_registered_schema(raw_schema, None)
+}
+
+pub fn get_schema_by_guid_and_type(
+    guid: &str,
+    sr_settings: &SrSettings,
+    schema_type: SchemaType,
+) -> Result<RegisteredSchema, SRCError> {
+    match get_schema_by_guid(guid, sr_settings) {
+        Ok(v) if v.schema_type == schema_type => Ok(v),
+        Ok(v) => Err(SRCError::non_retryable_without_cause(&format!(
+            "type {:?}, is not correct",
+            v.schema_type
+        ))),
+        Err(e) => Err(e),
+    }
+}
+
 /// Gets the registered schema by supplying a SubjectNameStrategy. This is used to as part of the
 /// encoding so we get the correct schema and id, and possible references.
 pub fn get_schema_by_subject(
@@ -293,6 +319,7 @@ fn raw_to_registered_schema(
         tags,
         subject: raw_schema.subject,
         version: raw_schema.version,
+        guid: raw_schema.guid,
     })
 }
 
@@ -332,7 +359,7 @@ pub fn post_schema(
         schema.properties.as_ref(),
         schema.tags.as_ref(),
     );
-    let id = call_and_get_id(sr_settings, SrCall::PostNew(&subject, &body))?;
+    let (id, guid) = call_and_get_id_and_guid(sr_settings, SrCall::PostNew(&subject, &body))?;
     Ok(RegisteredSchema {
         id,
         schema_type: schema.schema_type,
@@ -342,6 +369,7 @@ pub fn post_schema(
         tags: schema.tags,
         subject: Some(subject),
         version: None,
+        guid,
     })
 }
 
@@ -385,10 +413,15 @@ fn get_body(
     schema_element.to_string()
 }
 
-fn call_and_get_id(sr_setting: &SrSettings, sr_call: SrCall) -> Result<u32, SRCError> {
+/// Performs a schema registry call and extracts both the id and the guid from the response
+/// (`guid` is `None` against a schema registry older than 8.0, which doesn't return one).
+fn call_and_get_id_and_guid(
+    sr_setting: &SrSettings,
+    sr_call: SrCall,
+) -> Result<(u32, Option<String>), SRCError> {
     let raw_schema = perform_sr_call(sr_setting, sr_call)?;
     match raw_schema.id {
-        Some(v) => Ok(v),
+        Some(v) => Ok((v, raw_schema.guid)),
         None => Err(SRCError::non_retryable_without_cause(&format!(
             "Could not get id from response for {:?}",
             sr_call
@@ -514,9 +547,10 @@ fn perform_single_sr_call(
 ) -> Result<RawRegisteredSchema, SRCError> {
     let url = url_for_call(&sr_call, base_url);
     let builder = match sr_call {
-        SrCall::GetById(_) | SrCall::GetLatest(_) | SrCall::GetBySubjectAndVersion(_, _) => {
-            client.get(&url)
-        }
+        SrCall::GetById(_)
+        | SrCall::GetByGuid(_)
+        | SrCall::GetLatest(_)
+        | SrCall::GetBySubjectAndVersion(_, _) => client.get(&url),
         SrCall::PostNew(_, body) | SrCall::PostForVersion(_, body) => client
             .post(&url)
             .body(String::from(body))
@@ -859,6 +893,7 @@ mod tests {
             subject: Some("ietf-tls-common".to_string()),
             version: Some(1),
             id: Some(68),
+            guid: Some("9550709c-d6c9-0194-fefa-6381b953668d".to_string()),
             schema_type: Some("YANG".to_string()),
             references: Some(vec![
                 RegisteredReference {
@@ -933,6 +968,7 @@ mod tests {
             }),
             subject: Some("ietf-tls-common".to_string()),
             version: Some(1),
+            guid: Some("9550709c-d6c9-0194-fefa-6381b953668d".to_string()),
         };
 
         let parsed: RawRegisteredSchema = serde_json::from_str(json_str).expect("parse json");

--- a/src/blocking/schema_registry.rs
+++ b/src/blocking/schema_registry.rs
@@ -863,7 +863,7 @@ mod tests {
         let guid = "cc0e0e0e-53c1-4a1a-8f1a-000000000001";
 
         let _m = server
-            .mock("GET", format!("/schemas/guids/{guid}").as_str())
+            .mock("GET", format!("/schemas/guids/{guid}?deleted=true").as_str())
             .with_status(200)
             .with_header("content-type", "application/vnd.schemaregistry.v1+json")
             .with_body(r#"{"guid":"cc0e0e0e-53c1-4a1a-8f1a-000000000001","schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}","schemaType":"AVRO"}"#)

--- a/src/blocking/schema_registry.rs
+++ b/src/blocking/schema_registry.rs
@@ -229,7 +229,14 @@ pub fn get_schema_by_guid(
     sr_settings: &SrSettings,
 ) -> Result<RegisteredSchema, SRCError> {
     let raw_schema = perform_sr_call(sr_settings, SrCall::GetByGuid(guid))?;
-    raw_to_registered_schema(raw_schema, None)
+    // GET /schemas/guids/{guid} returns a `SchemaString` -- the same response shape as
+    // GET /schemas/ids/{id} -- which never carries an `id` field (Confluent's own model for it
+    // only has `guid`, not `id`). Unlike `get_schema_by_id`, there's no numeric id to pass in
+    // from the caller either, since not having one is the whole reason to look a schema up by
+    // guid. Default to 0 rather than erroring: nothing in the guid-based decode path depends on
+    // `RegisteredSchema.id` being a real registry id.
+    let id = raw_schema.id.unwrap_or(0);
+    raw_to_registered_schema(raw_schema, Some(id))
 }
 
 pub fn get_schema_by_guid_and_type(
@@ -747,7 +754,9 @@ pub fn is_compatible_schema(
 mod tests {
     use std::{collections::HashMap, time::Duration};
 
-    use crate::blocking::schema_registry::{get_schema_by_id, post_schema, SrSettings};
+    use crate::blocking::schema_registry::{
+        get_schema_by_guid, get_schema_by_id, post_schema, SrSettings,
+    };
     use crate::schema_registry_common::{
         Metadata, RawRegisteredSchema, RegisteredReference, RegisteredSchema, SchemaType,
         SuppliedSchema,
@@ -843,6 +852,32 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_get_schema_by_guid_without_id_in_response() {
+        // GET /schemas/guids/{guid} returns a `SchemaString` -- same as GET /schemas/ids/{id} --
+        // which never carries an "id" field on a real Confluent Schema Registry, only "guid".
+        // See https://github.com/gklijs/schema_registry_converter/issues/139.
+        let mut server = mockito::Server::new();
+        let guid = "cc0e0e0e-53c1-4a1a-8f1a-000000000001";
+
+        let _m = server
+            .mock("GET", format!("/schemas/guids/{guid}").as_str())
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"guid":"cc0e0e0e-53c1-4a1a-8f1a-000000000001","schema":"{\"type\":\"record\",\"name\":\"Heartbeat\",\"namespace\":\"nl.openweb.data\",\"fields\":[{\"name\":\"beat\",\"type\":\"long\"}]}","schemaType":"AVRO"}"#)
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+
+        let result = get_schema_by_guid(guid, &sr_settings)
+            .expect("guid lookup should succeed even without an id in the response");
+        assert_eq!(result.id, 0);
+        assert_eq!(result.guid, Some(guid.to_owned()));
     }
 
     #[test]

--- a/src/json_common.rs
+++ b/src/json_common.rs
@@ -5,6 +5,21 @@ use valico::json_schema::validators::ValidationState;
 use crate::error::SRCError;
 use crate::schema_registry_common::get_payload;
 
+/// Cap on how deep a chain of JSON schema `references` is followed before giving up with an
+/// `SRCError`. Without a cap, a circular reference chain (a schema that references itself,
+/// directly or transitively) recurses without bound -- each level makes a network call, so this
+/// is reached long before it could ever stack-overflow, turning what would otherwise be a hang/
+/// crash into a clean, actionable error. 32 is generously deep for any legitimate schema.
+pub(crate) const MAX_REFERENCE_DEPTH: usize = 32;
+
+pub(crate) fn reference_depth_exceeded_error() -> SRCError {
+    SRCError::non_retryable_without_cause(&format!(
+        "JSON schema reference chain exceeded {} levels -- this usually means a schema \
+         (transitively) references itself",
+        MAX_REFERENCE_DEPTH
+    ))
+}
+
 pub(crate) fn handle_validation(
     validation: ValidationState,
     value: &Value,
@@ -47,8 +62,14 @@ pub(crate) fn fetch_id(def: &Value) -> Option<Url> {
     Url::parse(id).ok()
 }
 
-pub(crate) fn fetch_fallback(url: &str, id: u32) -> Url {
-    let id = format!("{}/id/{}.json", url, id);
+/// `label` should uniquely identify the schema -- its numeric id when known, or its guid when
+/// the numeric id isn't available (e.g. a schema resolved via [`crate::schema_registry_common`]'s
+/// guid lookup, which -- unlike the id lookup -- never gets a real numeric id back from the
+/// registry). A non-unique label (e.g. the same placeholder for every guid-only lookup) would
+/// make two different schemas collide on the same fallback url and silently share one compiled
+/// schema.
+pub(crate) fn fetch_fallback(url: &str, label: &str) -> Url {
+    let id = format!("{}/id/{}.json", url, label);
     Url::parse(&id).unwrap()
 }
 

--- a/src/json_common.rs
+++ b/src/json_common.rs
@@ -25,13 +25,15 @@ pub(crate) fn handle_validation(
 }
 
 pub(crate) fn to_bytes(id: u32, value: &Value) -> Result<Vec<u8>, SRCError> {
-    match serde_json::to_vec(value) {
-        Ok(bytes) => Ok(get_payload(id, bytes)),
-        Err(e) => Err(SRCError::non_retryable_with_cause(
-            e,
-            "error serialising value to bytes",
-        )),
-    }
+    to_bytes_raw(value).map(|bytes| get_payload(id, bytes))
+}
+
+/// Like [`to_bytes`], but without the confluent wire-format prefix -- used when the schema
+/// id/guid is carried in a Kafka header instead. See
+/// https://github.com/gklijs/schema_registry_converter/issues/139.
+pub(crate) fn to_bytes_raw(value: &Value) -> Result<Vec<u8>, SRCError> {
+    serde_json::to_vec(value)
+        .map_err(|e| SRCError::non_retryable_with_cause(e, "error serialising value to bytes"))
 }
 
 pub(crate) fn fetch_id(def: &Value) -> Option<Url> {

--- a/src/proto_raw_common.rs
+++ b/src/proto_raw_common.rs
@@ -3,39 +3,39 @@ use crate::proto_resolver::{IndexResolver, MessageResolver};
 use crate::schema_registry_common::{get_payload, RegisteredSchema};
 use integer_encoding::VarInt;
 
-pub(crate) fn to_bytes(
+/// The message-index bytes for `full_name` in `encode_context`'s schema. This is the confluent
+/// wire format's way of pointing at which message in a (possibly multi-message) `.proto` schema
+/// a payload uses -- normally embedded in the payload right after the id, but for
+/// `_with_header_id` encoding it instead gets appended to the id/guid in the header (see
+/// [`crate::schema_registry_common::build_schema_id_header`]). See
+/// https://github.com/gklijs/schema_registry_converter/issues/139.
+pub(crate) fn index_bytes(
     encode_context: &EncodeContext,
-    bytes: &[u8],
     full_name: &str,
 ) -> Result<Vec<u8>, SRCError> {
-    let mut index_bytes = match encode_context.resolver.find_index(full_name) {
-        Some(v) if v.len() == 1 && v[0] == 0i32 => vec![0u8],
+    match encode_context.resolver.find_index(full_name) {
+        Some(v) if v.len() == 1 && v[0] == 0i32 => Ok(vec![0u8]),
         Some(v) => {
             let mut result = (v.len() as i32).encode_var_vec();
             for i in &*v {
                 result.append(&mut i.encode_var_vec())
             }
-            result
+            Ok(result)
         }
-        None => {
-            return Err(SRCError::non_retryable_without_cause(&format!(
-                "could not find name {} with resolver",
-                full_name
-            )))
-        }
-    };
-    index_bytes.extend(bytes);
-    Ok(get_payload(encode_context.id, index_bytes))
+        None => Err(SRCError::non_retryable_without_cause(&format!(
+            "could not find name {} with resolver",
+            full_name
+        ))),
+    }
 }
 
-pub(crate) fn to_bytes_single_message(
+/// Like [`index_bytes`], for the single-message case (`to_bytes_single_message`/
+/// `to_bytes_single_message_raw`).
+pub(crate) fn index_bytes_single_message(
     encode_context: &EncodeContext,
-    bytes: &[u8],
 ) -> Result<Vec<u8>, SRCError> {
     if encode_context.resolver.is_single_message() {
-        let mut index_bytes = vec![0u8];
-        index_bytes.extend(bytes);
-        Ok(get_payload(encode_context.id, index_bytes))
+        Ok(vec![0u8])
     } else {
         Err(SRCError::new(
             "Schema was no single message schema",
@@ -43,6 +43,25 @@ pub(crate) fn to_bytes_single_message(
             false,
         ))
     }
+}
+
+pub(crate) fn to_bytes(
+    encode_context: &EncodeContext,
+    bytes: &[u8],
+    full_name: &str,
+) -> Result<Vec<u8>, SRCError> {
+    let mut payload = index_bytes(encode_context, full_name)?;
+    payload.extend(bytes);
+    Ok(get_payload(encode_context.id, payload))
+}
+
+pub(crate) fn to_bytes_single_message(
+    encode_context: &EncodeContext,
+    bytes: &[u8],
+) -> Result<Vec<u8>, SRCError> {
+    let mut payload = index_bytes_single_message(encode_context)?;
+    payload.extend(bytes);
+    Ok(get_payload(encode_context.id, payload))
 }
 
 pub(crate) fn to_decode_context(registered_schema: RegisteredSchema) -> DecodeContext {
@@ -56,6 +75,10 @@ pub(crate) fn to_decode_context(registered_schema: RegisteredSchema) -> DecodeCo
 #[derive(Debug, Clone)]
 pub(crate) struct EncodeContext {
     pub(crate) id: u32,
+    /// The schema's UUID, as returned by Confluent Schema Registry 8.0+. `None` against an
+    /// older registry. Used by the `_with_header_id` encode methods to build a
+    /// [`crate::schema_registry_common::SchemaIdHeader`].
+    pub(crate) guid: Option<String>,
     pub(crate) resolver: IndexResolver,
 }
 

--- a/src/schema_registry_common.rs
+++ b/src/schema_registry_common.rs
@@ -90,6 +90,8 @@ pub struct RegisteredReference {
 /// Schema Registry includes them in `GET /schemas/ids/{id}` responses; an id can be registered
 /// against multiple subjects, so the value here is "the subject the registry returned" rather than
 /// an authoritative single answer. Use `GET /schemas/ids/{id}/subjects` if you need the full set.
+/// `guid` is the schema's UUID, as returned by Confluent Schema Registry 8.0+ alongside the int
+/// `id`. It's `None` against older registries. See [`SchemaIdHeader`].
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RegisteredSchema {
     pub id: u32,
@@ -100,6 +102,7 @@ pub struct RegisteredSchema {
     pub tags: Option<HashMap<String, Vec<String>>>,
     pub subject: Option<String>,
     pub version: Option<u32>,
+    pub guid: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -108,6 +111,7 @@ pub struct RawRegisteredSchema {
     pub subject: Option<String>,
     pub version: Option<u32>,
     pub id: Option<u32>,
+    pub guid: Option<String>,
     pub schema_type: Option<String>,
     pub references: Option<Vec<RegisteredReference>>,
     pub schema: Option<String>,
@@ -205,6 +209,7 @@ impl SubjectNameStrategy {
 #[derive(Debug, Clone, Copy)]
 pub enum SrCall<'a> {
     GetById(u32),
+    GetByGuid(&'a str),
     GetLatest(&'a str),
     GetBySubjectAndVersion(&'a str, u32),
     PostNew(&'a str, &'a str),
@@ -214,6 +219,7 @@ pub enum SrCall<'a> {
 pub(crate) fn url_for_call(call: &SrCall<'_>, base_url: &str) -> String {
     match call {
         SrCall::GetById(id) => format!("{}/schemas/ids/{}?deleted=true", base_url, id),
+        SrCall::GetByGuid(guid) => format!("{}/schemas/guids/{}", base_url, guid),
         SrCall::GetLatest(subject) => {
             // Use escape sequences instead of slashes in the subject
             format!(
@@ -294,12 +300,121 @@ pub fn invalid_bytes_error(bytes: &[u8]) -> String {
     }
 }
 
+/// Header name used for the schema id/guid of a Kafka record's key, matching Confluent's
+/// `SchemaId.KEY_SCHEMA_ID_HEADER`. See [`SchemaIdHeader`].
+pub const KEY_SCHEMA_ID_HEADER: &str = "__key_schema_id";
+/// Header name used for the schema id/guid of a Kafka record's value, matching Confluent's
+/// `SchemaId.VALUE_SCHEMA_ID_HEADER`. See [`SchemaIdHeader`].
+pub const VALUE_SCHEMA_ID_HEADER: &str = "__value_schema_id";
+
+/// A schema id/guid to attach to a Kafka record as a header, as an alternative to prefixing the
+/// payload (see [`get_payload`]). Produced by the `_with_header_id` encode methods, mirroring
+/// Confluent's `HeaderSchemaIdSerializer`.
+///
+/// This crate has no dependency on any particular Kafka client, so this is plain data: attach
+/// `value` under `name` using whatever `Headers`/`OwnedHeaders`/etc. type your Kafka client uses.
+/// See https://github.com/gklijs/schema_registry_converter/issues/139.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SchemaIdHeader {
+    pub name: &'static str,
+    pub value: Vec<u8>,
+}
+
+/// What a [`SchemaIdHeader`]'s bytes resolved to, produced by [`parse_schema_id_header`].
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum HeaderSchemaId {
+    Id(u32),
+    Guid(String),
+}
+
+/// Builds the bytes for a [`SchemaIdHeader`]: magic byte `0x01` (Confluent Schema Registry 8.0's
+/// GUID wire format) followed by the 16 raw bytes of `guid`, followed by `message_indexes`
+/// verbatim (used by the protobuf decoders to carry the message index that would otherwise be a
+/// payload-prefix; empty for Avro/JSON).
+pub(crate) fn build_schema_id_header(
+    name: &'static str,
+    guid: &str,
+    message_indexes: &[u8],
+) -> Result<SchemaIdHeader, SRCError> {
+    let raw = guid_to_bytes(guid)?;
+    let mut value = Vec::with_capacity(1 + raw.len() + message_indexes.len());
+    value.push(0x01);
+    value.extend_from_slice(&raw);
+    value.extend_from_slice(message_indexes);
+    Ok(SchemaIdHeader { name, value })
+}
+
+/// Parses the bytes of a `__key_schema_id`/`__value_schema_id` header, mirroring Confluent's
+/// `SchemaId.fromBytes`: magic byte `0x00` followed by a 4-byte id, or magic byte `0x01` followed
+/// by a 16-byte guid. Returns the id/guid plus whatever bytes follow it (the protobuf message
+/// index, when present; empty otherwise).
+pub(crate) fn parse_schema_id_header(bytes: &[u8]) -> Result<(HeaderSchemaId, &[u8]), SRCError> {
+    match bytes.first() {
+        Some(0x00) if bytes.len() >= 5 => {
+            let id = BigEndian::read_u32(&bytes[1..5]);
+            Ok((HeaderSchemaId::Id(id), &bytes[5..]))
+        }
+        Some(0x01) if bytes.len() >= 17 => {
+            Ok((HeaderSchemaId::Guid(bytes_to_guid(&bytes[1..17])), &bytes[17..]))
+        }
+        Some(b) => Err(SRCError::non_retryable_without_cause(&format!(
+            "Invalid schema id header: first byte is {:#04x}, expected magic byte 0x00 (id) or 0x01 (guid)",
+            b
+        ))),
+        None => Err(SRCError::non_retryable_without_cause(
+            "Invalid schema id header: empty",
+        )),
+    }
+}
+
+/// Parses a hyphenated or bare-hex UUID string into its 16 raw bytes.
+fn guid_to_bytes(guid: &str) -> Result<[u8; 16], SRCError> {
+    let hex: String = guid.chars().filter(|c| *c != '-').collect();
+    if hex.len() != 32 {
+        return Err(SRCError::non_retryable_without_cause(&format!(
+            "Invalid schema guid '{}': expected 32 hex characters (with or without dashes)",
+            guid
+        )));
+    }
+    let mut bytes = [0u8; 16];
+    for (i, b) in bytes.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).map_err(|e| {
+            SRCError::non_retryable_with_cause(e, &format!("Invalid schema guid '{}'", guid))
+        })?;
+    }
+    Ok(bytes)
+}
+
+/// Formats 16 raw bytes as a standard hyphenated UUID string.
+fn bytes_to_guid(bytes: &[u8]) -> String {
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15],
+    )
+}
+
 #[cfg(test)]
 mod test {
     use crate::error::SRCError;
     use crate::schema_registry_common::{
-        get_bytes_result, invalid_bytes_error, BytesResult, RegisteredSchema, SchemaType,
-        SrAuthorization, SubjectNameStrategy, SuppliedSchema,
+        build_schema_id_header, get_bytes_result, invalid_bytes_error, parse_schema_id_header,
+        BytesResult, HeaderSchemaId, RegisteredSchema, SchemaType, SrAuthorization,
+        SubjectNameStrategy, SuppliedSchema, KEY_SCHEMA_ID_HEADER,
     };
 
     #[test]
@@ -363,6 +478,7 @@ mod test {
             tags: None,
             subject: None,
             version: None,
+            guid: None,
         };
         assert_eq!(0, registered_schema.id);
         assert_eq!(SchemaType::Avro, registered_schema.schema_type);
@@ -372,8 +488,9 @@ mod test {
         assert!(registered_schema.tags.is_none());
         assert!(registered_schema.subject.is_none());
         assert!(registered_schema.version.is_none());
+        assert!(registered_schema.guid.is_none());
         assert_eq!(
-            r#"RegisteredSchema { id: 0, schema_type: Avro, schema: "some schema", references: [], properties: None, tags: None, subject: None, version: None }"#,
+            r#"RegisteredSchema { id: 0, schema_type: Avro, schema: "some schema", references: [], properties: None, tags: None, subject: None, version: None, guid: None }"#,
             format!("{:?}", registered_schema)
         )
     }
@@ -430,6 +547,70 @@ mod test {
     fn get_bytes_result_invalid() {
         let result = get_bytes_result(Some(&[0, 0, 0, 0]));
         assert_eq!(BytesResult::Invalid(&[0, 0, 0, 0]), result)
+    }
+
+    #[test]
+    fn build_and_parse_schema_id_header_round_trips_guid() {
+        let header = build_schema_id_header(
+            KEY_SCHEMA_ID_HEADER,
+            "cc0e0e0e-53c1-4a1a-8f1a-000000000001",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(KEY_SCHEMA_ID_HEADER, header.name);
+        assert_eq!(
+            &[
+                0x01, 0xcc, 0x0e, 0x0e, 0x0e, 0x53, 0xc1, 0x4a, 0x1a, 0x8f, 0x1a, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x01,
+            ],
+            header.value.as_slice()
+        );
+
+        let (schema_id, rest) = parse_schema_id_header(&header.value).unwrap();
+        assert_eq!(
+            HeaderSchemaId::Guid("cc0e0e0e-53c1-4a1a-8f1a-000000000001".to_string()),
+            schema_id
+        );
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn build_schema_id_header_keeps_trailing_message_indexes() {
+        let header = build_schema_id_header(
+            KEY_SCHEMA_ID_HEADER,
+            "00000000-0000-0000-0000-000000000000",
+            &[2, 4, 0],
+        )
+        .unwrap();
+        let (_, rest) = parse_schema_id_header(&header.value).unwrap();
+        assert_eq!(&[2, 4, 0], rest);
+    }
+
+    #[test]
+    fn build_schema_id_header_invalid_guid() {
+        let err = build_schema_id_header(KEY_SCHEMA_ID_HEADER, "not-a-guid", &[]).unwrap_err();
+        assert!(err.error.starts_with("Invalid schema guid 'not-a-guid'"));
+    }
+
+    #[test]
+    fn parse_schema_id_header_id_variant() {
+        let (schema_id, rest) = parse_schema_id_header(&[0x00, 0, 0, 0, 7]).unwrap();
+        assert_eq!(HeaderSchemaId::Id(7), schema_id);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn parse_schema_id_header_unknown_magic_byte() {
+        let err = parse_schema_id_header(&[0x02, 0, 0, 0, 0]).unwrap_err();
+        assert!(err
+            .error
+            .starts_with("Invalid schema id header: first byte is 0x02"));
+    }
+
+    #[test]
+    fn parse_schema_id_header_empty() {
+        let err = parse_schema_id_header(&[]).unwrap_err();
+        assert_eq!("Invalid schema id header: empty", err.error);
     }
 
     #[test]

--- a/src/schema_registry_common.rs
+++ b/src/schema_registry_common.rs
@@ -219,7 +219,10 @@ pub enum SrCall<'a> {
 pub(crate) fn url_for_call(call: &SrCall<'_>, base_url: &str) -> String {
     match call {
         SrCall::GetById(id) => format!("{}/schemas/ids/{}?deleted=true", base_url, id),
-        SrCall::GetByGuid(guid) => format!("{}/schemas/guids/{}", base_url, guid),
+        // `deleted=true` matters here just like it does for GetById: a consumer decoding an old
+        // Kafka message whose header carries a guid must still be able to resolve it even if the
+        // subject/version it was registered under has since been soft-deleted.
+        SrCall::GetByGuid(guid) => format!("{}/schemas/guids/{}?deleted=true", base_url, guid),
         SrCall::GetLatest(subject) => {
             // Use escape sequences instead of slashes in the subject
             format!(
@@ -344,6 +347,32 @@ pub(crate) fn build_schema_id_header(
     Ok(SchemaIdHeader { name, value })
 }
 
+/// Builds the [`SchemaIdHeader`] for an `encode_with_header_id` call: picks the
+/// `__key_schema_id`/`__value_schema_id` header name based on `is_key`, and errors out if the
+/// schema has no `guid` (a registry older than Confluent Schema Registry 8.0, which doesn't
+/// return one). `message_indexes` is the protobuf message index that would otherwise be a
+/// payload-prefix (empty for Avro/JSON). Shared by every encoder (Avro, JSON, protobuf; blocking
+/// and async) so the guid-required error message and header-name selection can't drift between
+/// them.
+pub(crate) fn schema_id_header_for(
+    guid: Option<&str>,
+    is_key: bool,
+    message_indexes: &[u8],
+) -> Result<SchemaIdHeader, SRCError> {
+    let guid = guid.ok_or_else(|| {
+        SRCError::non_retryable_without_cause(
+            "Schema registry response did not include a guid; encoding the schema id in a \
+             header requires Confluent Schema Registry 8.0+",
+        )
+    })?;
+    let name = if is_key {
+        KEY_SCHEMA_ID_HEADER
+    } else {
+        VALUE_SCHEMA_ID_HEADER
+    };
+    build_schema_id_header(name, guid, message_indexes)
+}
+
 /// Parses the bytes of a `__key_schema_id`/`__value_schema_id` header, mirroring Confluent's
 /// `SchemaId.fromBytes`: magic byte `0x00` followed by a 4-byte id, or magic byte `0x01` followed
 /// by a 16-byte guid. Returns the id/guid plus whatever bytes follow it (the protobuf message
@@ -354,9 +383,17 @@ pub(crate) fn parse_schema_id_header(bytes: &[u8]) -> Result<(HeaderSchemaId, &[
             let id = BigEndian::read_u32(&bytes[1..5]);
             Ok((HeaderSchemaId::Id(id), &bytes[5..]))
         }
+        Some(0x00) => Err(SRCError::non_retryable_without_cause(&format!(
+            "Invalid schema id header: {} bytes, expected at least 5 (magic byte 0x00 + 4-byte id)",
+            bytes.len()
+        ))),
         Some(0x01) if bytes.len() >= 17 => {
             Ok((HeaderSchemaId::Guid(bytes_to_guid(&bytes[1..17])), &bytes[17..]))
         }
+        Some(0x01) => Err(SRCError::non_retryable_without_cause(&format!(
+            "Invalid schema id header: {} bytes, expected at least 17 (magic byte 0x01 + 16-byte guid)",
+            bytes.len()
+        ))),
         Some(b) => Err(SRCError::non_retryable_without_cause(&format!(
             "Invalid schema id header: first byte is {:#04x}, expected magic byte 0x00 (id) or 0x01 (guid)",
             b
@@ -611,6 +648,27 @@ mod test {
     fn parse_schema_id_header_empty() {
         let err = parse_schema_id_header(&[]).unwrap_err();
         assert_eq!("Invalid schema id header: empty", err.error);
+    }
+
+    #[test]
+    fn parse_schema_id_header_truncated_id() {
+        // A correctly-prefixed but truncated header must be reported as truncated, not
+        // misattributed to a wrong magic byte (the byte at index 0 *is* the valid 0x00 magic
+        // byte -- there just aren't enough bytes after it).
+        let err = parse_schema_id_header(&[0x00, 0, 0]).unwrap_err();
+        assert_eq!(
+            "Invalid schema id header: 3 bytes, expected at least 5 (magic byte 0x00 + 4-byte id)",
+            err.error
+        );
+    }
+
+    #[test]
+    fn parse_schema_id_header_truncated_guid() {
+        let err = parse_schema_id_header(&[0x01, 0, 0]).unwrap_err();
+        assert_eq!(
+            "Invalid schema id header: 3 bytes, expected at least 17 (magic byte 0x01 + 16-byte guid)",
+            err.error
+        );
     }
 
     #[test]

--- a/tests/blocking/avro_tests.rs
+++ b/tests/blocking/avro_tests.rs
@@ -1,6 +1,8 @@
 extern crate schema_registry_converter;
 
-use crate::blocking::avro_consumer::{consume_avro, DeserializedAvroRecord};
+use crate::blocking::avro_consumer::{
+    consume_avro, consume_avro_with_header_id, DeserializedAvroRecord,
+};
 use crate::blocking::kafka_producer::get_producer;
 use apache_avro::types::Value;
 use rand::prelude::*;
@@ -139,68 +141,89 @@ fn test3_topic_record_name_strategy_with_schema() {
     do_avro_test(topic, key_strategy, value_strategy)
 }
 
+/// Assertions shared by `test4_test_avro_from_java_test_app` and
+/// `test5_test_avro_header_id_from_java_test_app`: both consume the same `AvroTest` value the
+/// Java test app produces (see `TestAvro.testValue()`), just via different wire formats.
+fn assert_java_avro_test_record(rec: DeserializedAvroRecord) {
+    println!("testing record {:#?}", rec);
+    match rec.key {
+        Value::String(s) => assert_eq!("testkey", s, "check string key"),
+        _ => panic!("Keys wasn't a string"),
+    };
+    let value_values = match rec.value {
+        Value::Record(v) => v,
+        _ => panic!("Not a record, while only only those expected"),
+    };
+    let id_key = match &value_values[0] {
+        (_id, Value::Fixed(16, _v)) => _id,
+        _ => panic!("Not a fixed value of 16 bytes while that was expected"),
+    };
+    assert_eq!("id", id_key, "expected id key to be id");
+    let enum_value = match &value_values[1] {
+        (_id, Value::Enum(0, v)) => v,
+        _ => panic!("Not an enum value for by while that was expected"),
+    };
+    assert_eq!("Java", enum_value, "expect message from Java");
+    let counter_value = match &value_values[2] {
+        (_id, Value::Long(v)) => v,
+        _ => panic!("Not a long value for counter while that was expected"),
+    };
+    assert_eq!(&1i64, counter_value, "counter is 1");
+    let input_value = match &value_values[3] {
+        (_id, Value::Union(_, v)) => v,
+        _ => panic!("Not an unions value for input while that was expected"),
+    };
+    assert_eq!(
+        &Box::new(Value::String(String::from("String"))),
+        input_value,
+        "Optional string is string"
+    );
+    let results = match &value_values[4] {
+        (_id, Value::Array(v)) => v,
+        _ => panic!("Not an array value for results while that was expected"),
+    };
+    let result = match results.first().expect("one item to be present") {
+        Value::Record(v) => v,
+        _ => panic!("Not record for first of results while that was expected"),
+    };
+    let up_result = match &result[0] {
+        (_id, Value::String(v)) => v,
+        _ => panic!("First result value wasn't a string"),
+    };
+    assert_eq!("STRING", up_result, "expected upper case string");
+    let down_result = match &result[1] {
+        (_id, Value::String(v)) => v,
+        _ => panic!("Second result value wasn't a string"),
+    };
+    assert_eq!("string", down_result, "expected upper case string");
+}
+
 #[test]
 fn test4_test_avro_from_java_test_app() {
     let topic = "testavro";
-    let test = Box::new(move |rec: DeserializedAvroRecord| {
-        println!("testing record {:#?}", rec);
-        match rec.key {
-            Value::String(s) => assert_eq!("testkey", s, "check string key"),
-            _ => panic!("Keys wasn't a string"),
-        };
-        let value_values = match rec.value {
-            Value::Record(v) => v,
-            _ => panic!("Not a record, while only only those expected"),
-        };
-        let id_key = match &value_values[0] {
-            (_id, Value::Fixed(16, _v)) => _id,
-            _ => panic!("Not a fixed value of 16 bytes while that was expected"),
-        };
-        assert_eq!("id", id_key, "expected id key to be id");
-        let enum_value = match &value_values[1] {
-            (_id, Value::Enum(0, v)) => v,
-            _ => panic!("Not an enum value for by while that was expected"),
-        };
-        assert_eq!("Java", enum_value, "expect message from Java");
-        let counter_value = match &value_values[2] {
-            (_id, Value::Long(v)) => v,
-            _ => panic!("Not a long value for counter while that was expected"),
-        };
-        assert_eq!(&1i64, counter_value, "counter is 1");
-        let input_value = match &value_values[3] {
-            (_id, Value::Union(_, v)) => v,
-            _ => panic!("Not an unions value for input while that was expected"),
-        };
-        assert_eq!(
-            &Box::new(Value::String(String::from("String"))),
-            input_value,
-            "Optional string is string"
-        );
-        let results = match &value_values[4] {
-            (_id, Value::Array(v)) => v,
-            _ => panic!("Not an array value for results while that was expected"),
-        };
-        let result = match results.first().expect("one item to be present") {
-            Value::Record(v) => v,
-            _ => panic!("Not record for first of results while that was expected"),
-        };
-        let up_result = match &result[0] {
-            (_id, Value::String(v)) => v,
-            _ => panic!("First result value wasn't a string"),
-        };
-        assert_eq!("STRING", up_result, "expected upper case string");
-        let down_result = match &result[1] {
-            (_id, Value::String(v)) => v,
-            _ => panic!("Second result value wasn't a string"),
-        };
-        assert_eq!("string", down_result, "expected upper case string");
-    });
     consume_avro(
         get_brokers(),
         "test",
         get_schema_registry_url(),
         &[topic],
         false,
-        test,
+        Box::new(assert_java_avro_test_record),
+    )
+}
+
+#[test]
+fn test5_test_avro_header_id_from_java_test_app() {
+    // Consumes what the Java test app produces to "testavroheader" via HeaderSchemaIdSerializer
+    // -- same AvroTest value as test4, but with the schema guid in a __value_schema_id header
+    // instead of the payload prefix. See
+    // https://github.com/gklijs/schema_registry_converter/issues/139.
+    let topic = "testavroheader";
+    consume_avro_with_header_id(
+        get_brokers(),
+        "test",
+        get_schema_registry_url(),
+        &[topic],
+        false,
+        Box::new(assert_java_avro_test_record),
     )
 }

--- a/tests/blocking/json_consumer.rs
+++ b/tests/blocking/json_consumer.rs
@@ -1,33 +1,37 @@
-use crate::blocking::kafka_consumer::get_consumer;
-use apache_avro::types::Value;
 use rdkafka::message::{BorrowedMessage, Headers};
 use rdkafka::Message;
-use schema_registry_converter::blocking::avro::AvroDecoder;
+use serde_json::Value;
+
+use schema_registry_converter::blocking::json::JsonDecoder;
 use schema_registry_converter::blocking::schema_registry::SrSettings;
 use schema_registry_converter::schema_registry_common::VALUE_SCHEMA_ID_HEADER;
 
+use crate::blocking::kafka_consumer::get_consumer;
+
 #[derive(Debug)]
-pub struct DeserializedAvroRecord<'a> {
-    pub key: Value,
+pub struct DeserializedJsonRecord<'a> {
+    pub key: String,
     pub value: Value,
     pub topic: &'a str,
     pub partition: i32,
     pub offset: i64,
 }
 
-pub fn consume_avro(
+/// Consumes a message encoded with the default confluent wire format (schema id prefixing the
+/// payload).
+pub fn consume_json(
     brokers: &str,
     group_id: &str,
     registry: String,
     topics: &[&str],
     auto_commit: bool,
-    test: Box<dyn Fn(DeserializedAvroRecord)>,
+    test: Box<dyn Fn(DeserializedJsonRecord)>,
 ) {
     let sr_settings = SrSettings::new_builder(registry)
         .no_proxy()
         .build()
         .unwrap();
-    let decoder = AvroDecoder::new(sr_settings);
+    let mut decoder = JsonDecoder::new(sr_settings);
     let consumer = get_consumer(brokers, group_id, topics, auto_commit);
 
     match consumer.iter().next() {
@@ -36,25 +40,26 @@ pub fn consume_avro(
                 panic!("Got error consuming message: {}", e);
             }
             Ok(m) => {
-                let des_r = get_deserialized_avro_record(&m, &decoder);
+                let des_r = get_deserialized_json_record(&m, &mut decoder);
                 test(des_r);
             }
         },
-        None => panic!("No record received in avro consumer, while that was expected"),
+        None => panic!("No record received in json consumer, while that was expected"),
     };
 }
 
-fn get_deserialized_avro_record<'a>(
+fn get_deserialized_json_record<'a>(
     m: &'a BorrowedMessage,
-    decoder: &'a AvroDecoder,
-) -> DeserializedAvroRecord<'a> {
-    let key = deserialize_key(m, decoder);
+    decoder: &mut JsonDecoder,
+) -> DeserializedJsonRecord<'a> {
+    let key = deserialize_key(m);
     print!("value needed for test {:?}", m.payload());
     let value = match decoder.decode(m.payload()) {
-        Ok(v) => v.value,
+        Ok(Some(v)) => v.value,
+        Ok(None) => panic!("Expected a value, got a tombstone"),
         Err(e) => panic!("Error getting value: {}", e),
     };
-    DeserializedAvroRecord {
+    DeserializedJsonRecord {
         key,
         value,
         topic: m.topic(),
@@ -63,42 +68,33 @@ fn get_deserialized_avro_record<'a>(
     }
 }
 
-fn deserialize_key<'a>(m: &'a BorrowedMessage, decoder: &'a AvroDecoder) -> Value {
-    match decoder.decode(m.key()) {
-        Ok(v) => v.value,
-        Err(e) => {
-            println!(
-                "encountered error, key probably was not avro encoded: {}",
-                e
-            );
-            match String::from_utf8(Vec::from(m.key().unwrap())) {
-                Ok(s) => Value::String(s),
-                Err(_) => {
-                    println!("It was not a String either :(");
-                    Value::Bytes(Vec::from(m.key().unwrap()))
-                }
-            }
+fn deserialize_key(m: &BorrowedMessage) -> String {
+    match String::from_utf8(Vec::from(m.key().unwrap())) {
+        Ok(s) => s,
+        Err(_) => {
+            println!("It was not a String.. Setting empty string");
+            String::from("")
         }
     }
 }
 
-/// Like [`consume_avro`], but for a message whose schema id/guid is carried in a
+/// Like [`consume_json`], but for a message whose schema id/guid is carried in a
 /// `__value_schema_id` header instead of the payload prefix, mirroring Confluent's
 /// `HeaderSchemaIdSerializer`/`DualSchemaIdDeserializer`. See
 /// https://github.com/gklijs/schema_registry_converter/issues/139.
-pub fn consume_avro_with_header_id(
+pub fn consume_json_with_header_id(
     brokers: &str,
     group_id: &str,
     registry: String,
     topics: &[&str],
     auto_commit: bool,
-    test: Box<dyn Fn(DeserializedAvroRecord)>,
+    test: Box<dyn Fn(DeserializedJsonRecord)>,
 ) {
     let sr_settings = SrSettings::new_builder(registry)
         .no_proxy()
         .build()
         .unwrap();
-    let decoder = AvroDecoder::new(sr_settings);
+    let mut decoder = JsonDecoder::new(sr_settings);
     let consumer = get_consumer(brokers, group_id, topics, auto_commit);
 
     match consumer.iter().next() {
@@ -107,30 +103,32 @@ pub fn consume_avro_with_header_id(
                 panic!("Got error consuming message: {}", e);
             }
             Ok(m) => {
-                let des_r = get_deserialized_avro_record_with_header_id(&m, &decoder);
+                let des_r = get_deserialized_json_record_with_header_id(&m, &mut decoder);
                 test(des_r);
             }
         },
-        None => panic!("No record received in avro consumer, while that was expected"),
+        None => panic!("No record received in json consumer, while that was expected"),
     };
 }
 
-fn get_deserialized_avro_record_with_header_id<'a>(
+fn get_deserialized_json_record_with_header_id<'a>(
     m: &'a BorrowedMessage,
-    decoder: &'a AvroDecoder,
-) -> DeserializedAvroRecord<'a> {
-    let key = deserialize_key(m, decoder);
+    decoder: &mut JsonDecoder,
+) -> DeserializedJsonRecord<'a> {
+    let key = deserialize_key(m);
     let header_value = m.headers().and_then(|headers| {
         headers
             .iter()
             .find(|h| h.key == VALUE_SCHEMA_ID_HEADER)
             .and_then(|h| h.value)
     });
+    print!("value needed for test {:?}", m.payload());
     let value = match decoder.decode_with_header_id(header_value, m.payload()) {
-        Ok(v) => v.value,
+        Ok(Some(v)) => v.value,
+        Ok(None) => panic!("Expected a value, got a tombstone"),
         Err(e) => panic!("Error getting value: {}", e),
     };
-    DeserializedAvroRecord {
+    DeserializedJsonRecord {
         key,
         value,
         topic: m.topic(),

--- a/tests/blocking/json_tests.rs
+++ b/tests/blocking/json_tests.rs
@@ -1,0 +1,101 @@
+extern crate schema_registry_converter;
+
+use serde_json::Value;
+
+use crate::blocking::json_consumer::{
+    consume_json, consume_json_with_header_id, DeserializedJsonRecord,
+};
+
+fn get_schema_registry_url() -> String {
+    String::from("http://localhost:8081")
+}
+
+fn get_brokers() -> &'static str {
+    "127.0.0.1:9092"
+}
+
+/// Assertions shared by `test1_test_json_from_java_test_app` and
+/// `test2_test_json_header_id_from_java_test_app`: both consume the same `JsonTest` value the
+/// Java test app produces (see `TestJson.testValue()`), just via different wire formats.
+fn assert_java_json_test_record(rec: DeserializedJsonRecord, topic: &str) {
+    println!("testing record {:#?}", rec);
+    assert_eq!(String::from("testkey"), rec.key, "check string key");
+    let value = match &rec.value {
+        Value::Object(v) => v,
+        _ => panic!("Not an object value while that was expected"),
+    };
+    match value.get("id") {
+        Some(Value::Array(v)) => assert_eq!(16, v.len(), "expected id of 16 size"),
+        _ => panic!("Not an array value for id while that was expected"),
+    };
+    assert_eq!(
+        Some(&Value::String(String::from("Java"))),
+        value.get("by"),
+        "expect message from Java"
+    );
+    assert_eq!(Some(&Value::from(1)), value.get("counter"), "counter is 1");
+    assert_eq!(
+        Some(&Value::String(String::from("String"))),
+        value.get("input"),
+        "Optional string is string"
+    );
+    let results = match value.get("results") {
+        Some(Value::Array(v)) => v,
+        _ => panic!("Not an array value for results while that was expected"),
+    };
+    let result = match results.first().expect("one item to be present") {
+        Value::Object(v) => v,
+        _ => panic!("Not an object for first of results while that was expected"),
+    };
+    assert_eq!(
+        Some(&Value::String(String::from("STRING"))),
+        result.get("up"),
+        "expected upper case string"
+    );
+    assert_eq!(
+        Some(&Value::String(String::from("string"))),
+        result.get("down"),
+        "expected lower case string"
+    );
+    assert_eq!(
+        rec.topic, topic,
+        "Topic in record should match the actual topic"
+    );
+    assert!(
+        rec.partition >= 0,
+        "Partition in record should be a positive number"
+    );
+    assert!(
+        rec.offset >= 0,
+        "Offset in record should be a positive number"
+    );
+}
+
+#[test]
+fn test1_test_json_from_java_test_app() {
+    let topic = "testjson";
+    consume_json(
+        get_brokers(),
+        "test",
+        get_schema_registry_url(),
+        &[topic],
+        false,
+        Box::new(move |rec| assert_java_json_test_record(rec, topic)),
+    )
+}
+
+#[test]
+fn test2_test_json_header_id_from_java_test_app() {
+    // Consumes what the Java test app produces to "testjsonheader" via HeaderSchemaIdSerializer:
+    // the schema guid goes in a __value_schema_id header instead of the payload prefix. See
+    // https://github.com/gklijs/schema_registry_converter/issues/139.
+    let topic = "testjsonheader";
+    consume_json_with_header_id(
+        get_brokers(),
+        "test",
+        get_schema_registry_url(),
+        &[topic],
+        false,
+        Box::new(move |rec| assert_java_json_test_record(rec, topic)),
+    )
+}

--- a/tests/blocking/mod.rs
+++ b/tests/blocking/mod.rs
@@ -2,6 +2,10 @@
 pub mod avro_consumer;
 #[cfg(feature = "avro")]
 mod avro_tests;
+#[cfg(feature = "json")]
+pub mod json_consumer;
+#[cfg(feature = "json")]
+mod json_tests;
 pub mod kafka_consumer;
 pub mod kafka_producer;
 #[cfg(feature = "proto_decoder")]

--- a/tests/blocking/proto_consumer.rs
+++ b/tests/blocking/proto_consumer.rs
@@ -1,9 +1,10 @@
 use protofish::decode::Value;
-use rdkafka::message::BorrowedMessage;
+use rdkafka::message::{BorrowedMessage, Headers};
 use rdkafka::Message;
 
 use schema_registry_converter::blocking::proto_decoder::ProtoDecoder;
 use schema_registry_converter::blocking::schema_registry::SrSettings;
+use schema_registry_converter::schema_registry_common::VALUE_SCHEMA_ID_HEADER;
 
 use crate::blocking::kafka_consumer::get_consumer;
 
@@ -49,15 +50,76 @@ fn get_deserialized_proto_record<'a>(
     m: &'a BorrowedMessage,
     decoder: &'a ProtoDecoder,
 ) -> DeserializedProtoRecord<'a> {
-    let key = match String::from_utf8(Vec::from(m.key().unwrap())) {
+    let key = deserialize_key(m);
+    print!("value needed for test {:?}", m.payload());
+    let value = match decoder.decode(m.payload()) {
+        Ok(v) => v,
+        Err(e) => panic!("Error getting value: {}", e),
+    };
+    DeserializedProtoRecord {
+        key,
+        value,
+        topic: m.topic(),
+        partition: m.partition(),
+        offset: m.offset(),
+    }
+}
+
+fn deserialize_key(m: &BorrowedMessage) -> String {
+    match String::from_utf8(Vec::from(m.key().unwrap())) {
         Ok(s) => s,
         Err(_) => {
             println!("It was not a String.. Setting empty string");
             String::from("")
         }
+    }
+}
+
+/// Like [`consume_proto`], but for a message whose schema id/guid (and message index) is
+/// carried in a `__value_schema_id` header instead of the payload prefix, mirroring Confluent's
+/// `HeaderSchemaIdSerializer`/`DualSchemaIdDeserializer`. See
+/// https://github.com/gklijs/schema_registry_converter/issues/139.
+pub fn consume_proto_with_header_id(
+    brokers: &str,
+    group_id: &str,
+    registry: String,
+    topics: &[&str],
+    auto_commit: bool,
+    test: Box<dyn Fn(DeserializedProtoRecord)>,
+) {
+    let sr_settings = SrSettings::new_builder(registry)
+        .no_proxy()
+        .build()
+        .unwrap();
+    let decoder = ProtoDecoder::new(sr_settings);
+    let consumer = get_consumer(brokers, group_id, topics, auto_commit);
+
+    match consumer.iter().next() {
+        Some(r) => match r {
+            Err(e) => {
+                panic!("Got error producing message: {}", e);
+            }
+            Ok(m) => {
+                let des_r = get_deserialized_proto_record_with_header_id(&m, &decoder);
+                test(des_r);
+            }
+        },
+        None => panic!("No next record for proto consumer"),
     };
-    print!("value needed for test {:?}", m.payload());
-    let value = match decoder.decode(m.payload()) {
+}
+
+fn get_deserialized_proto_record_with_header_id<'a>(
+    m: &'a BorrowedMessage,
+    decoder: &'a ProtoDecoder,
+) -> DeserializedProtoRecord<'a> {
+    let key = deserialize_key(m);
+    let header_value = m.headers().and_then(|headers| {
+        headers
+            .iter()
+            .find(|h| h.key == VALUE_SCHEMA_ID_HEADER)
+            .and_then(|h| h.value)
+    });
+    let value = match decoder.decode_with_header_id(header_value, m.payload()) {
         Ok(v) => v,
         Err(e) => panic!("Error getting value: {}", e),
     };

--- a/tests/blocking/proto_tests.rs
+++ b/tests/blocking/proto_tests.rs
@@ -2,7 +2,9 @@ extern crate schema_registry_converter;
 
 use protofish::decode::Value;
 
-use crate::blocking::proto_consumer::{consume_proto, DeserializedProtoRecord};
+use crate::blocking::proto_consumer::{
+    consume_proto, consume_proto_with_header_id, DeserializedProtoRecord,
+};
 
 pub fn get_schema_registry_url() -> String {
     String::from("http://localhost:8081")
@@ -12,77 +14,81 @@ fn get_brokers() -> &'static str {
     "127.0.0.1:9092"
 }
 
+/// Assertions shared by `test1_test_proto_from_java_test_app` and
+/// `test3_test_proto_header_id_from_java_test_app`: both consume the same `ProtoTest` value the
+/// Java test app produces (see `TestProto.testValue()`), just via different wire formats.
+fn assert_java_proto_test_record(rec: DeserializedProtoRecord, topic: &str) {
+    println!("testing record {:#?}", rec);
+    assert_eq!(String::from("testkey"), rec.key, "check string key");
+    let value_values = match rec.value {
+        Value::Message(v) => v.fields,
+        _ => panic!("Not a message value while that was expected"),
+    };
+    match &value_values[0].value {
+        Value::Bytes(v) => assert_eq!(16, v.len(), "expected id of 16 size"),
+        _ => panic!("Not a bytes value for counter while that was expected"),
+    };
+    let counter_value = match &value_values[1].value {
+        Value::Int64(v) => v,
+        _ => panic!("Not a long value for counter while that was expected"),
+    };
+    assert_eq!(&1, counter_value, "counter is 1");
+    let input_value = match &value_values[2].value {
+        Value::String(v) => v,
+        _ => panic!("Not a string value for input while that was expected"),
+    };
+    assert_eq!(
+        &String::from("String"),
+        input_value,
+        "Optional string is string"
+    );
+    let results = match &value_values[3].value {
+        Value::Message(v) => v.fields.clone(),
+        _ => panic!("Not an array value for results while that was expected"),
+    };
+    assert_eq!(2, results.len(), "Expect two result");
+    let input_value = match &results[0].value {
+        Value::String(v) => v,
+        _ => panic!("Not a string value for input while that was expected"),
+    };
+    assert_eq!(
+        &String::from("STRING"),
+        input_value,
+        "Optional string is STRING"
+    );
+    let input_value = match &results[1].value {
+        Value::String(v) => v,
+        _ => panic!("Not a string value for input while that was expected"),
+    };
+    assert_eq!(
+        &String::from("string"),
+        input_value,
+        "Optional string is string"
+    );
+    assert_eq!(
+        rec.topic, topic,
+        "Topic in record should match the actual topic"
+    );
+    assert!(
+        rec.partition >= 0,
+        "Partition in record should be a positive number"
+    );
+    assert!(
+        rec.offset >= 0,
+        "Offset in record should be a positive number"
+    );
+}
+
 #[test]
 fn test1_test_proto_from_java_test_app() {
     let topic = "testproto";
-    let test = Box::new(move |rec: DeserializedProtoRecord| {
-        println!("testing record {:#?}", rec);
-        assert_eq!(String::from("testkey"), rec.key, "check string key");
-        let value_values = match rec.value {
-            Value::Message(v) => v.fields,
-            _ => panic!("Not a message value while that was expected"),
-        };
-        match &value_values[0].value {
-            Value::Bytes(v) => assert_eq!(16, v.len(), "expected id of 16 size"),
-            _ => panic!("Not a bytes value for counter while that was expected"),
-        };
-        let counter_value = match &value_values[1].value {
-            Value::Int64(v) => v,
-            _ => panic!("Not a long value for counter while that was expected"),
-        };
-        assert_eq!(&1, counter_value, "counter is 1");
-        let input_value = match &value_values[2].value {
-            Value::String(v) => v,
-            _ => panic!("Not a string value for input while that was expected"),
-        };
-        assert_eq!(
-            &String::from("String"),
-            input_value,
-            "Optional string is string"
-        );
-        let results = match &value_values[3].value {
-            Value::Message(v) => v.fields.clone(),
-            _ => panic!("Not an array value for results while that was expected"),
-        };
-        assert_eq!(2, results.len(), "Expect two result");
-        let input_value = match &results[0].value {
-            Value::String(v) => v,
-            _ => panic!("Not a string value for input while that was expected"),
-        };
-        assert_eq!(
-            &String::from("STRING"),
-            input_value,
-            "Optional string is STRING"
-        );
-        let input_value = match &results[1].value {
-            Value::String(v) => v,
-            _ => panic!("Not a string value for input while that was expected"),
-        };
-        assert_eq!(
-            &String::from("string"),
-            input_value,
-            "Optional string is string"
-        );
-        assert_eq!(
-            rec.topic, topic,
-            "Topic in record should match the actual topic"
-        );
-        assert!(
-            rec.partition >= 0,
-            "Partition in record should be a positive number"
-        );
-        assert!(
-            rec.offset >= 0,
-            "Offset in record should be a positive number"
-        );
-    });
     consume_proto(
         get_brokers(),
         "test",
         get_schema_registry_url(),
         &[topic],
         false,
-        test,
+        Box::new(move |rec| assert_java_proto_test_record(rec, topic)),
     )
 }
 
@@ -104,5 +110,22 @@ fn test2_test_google_proto_from_java_test_app() {
         &[topic],
         false,
         test,
+    )
+}
+
+#[test]
+fn test3_test_proto_header_id_from_java_test_app() {
+    // Consumes what the Java test app produces to "testprotoheader" via HeaderSchemaIdSerializer
+    // -- same ProtoTest value as test1, but with the schema guid (and message index) in a
+    // __value_schema_id header instead of the payload prefix. See
+    // https://github.com/gklijs/schema_registry_converter/issues/139.
+    let topic = "testprotoheader";
+    consume_proto_with_header_id(
+        get_brokers(),
+        "test",
+        get_schema_registry_url(),
+        &[topic],
+        false,
+        Box::new(move |rec| assert_java_proto_test_record(rec, topic)),
     )
 }


### PR DESCRIPTION
Confluent Schema Registry 8.0 introduced an alternative wire format where the schema id/guid travels in a __key_schema_id/__value_schema_id Kafka header instead of being prefixed onto the payload, mirroring the Java client's HeaderSchemaIdSerializer/DualSchemaIdDeserializer. This adds that as an opt-in alternative alongside the existing payload-prefix format, for Avro, JSON and protobuf, blocking and async.

- schema_registry_common: new SchemaIdHeader type, KEY_SCHEMA_ID_HEADER/ VALUE_SCHEMA_ID_HEADER constants, and build_schema_id_header/ parse_schema_id_header helpers implementing Confluent's header wire format (magic byte 0x00 + 4-byte id, or 0x01 + 16-byte guid, followed by any protobuf message index). SrCall gains GetByGuid, and RegisteredSchema/RawRegisteredSchema gain a `guid` field.
- blocking/async schema_registry: schema lookup by guid via GET /schemas/guids/{guid}, alongside the existing lookup by id.
- AvroEncoder/AvroDecoder, JsonEncoder/JsonDecoder, ProtoRawEncoder/ ProtoRawDecoder and ProtoDecoder (blocking + async) all gain `_with_header_id` encode/decode variants. Encoding returns (payload, SchemaIdHeader) with an unprefixed payload; decoding takes the header bytes alongside the payload and falls through to the regular decode when no header is present, so a consumer can handle both wire formats during a migration.
- This crate has no Kafka client dependency, so SchemaIdHeader is plain data -- callers attach it to a record header themselves.
- docker-compose.yaml bumped to Confluent Platform 8.3.1 in KRaft mode (cp-zookeeper is no longer published for 8.x, so the zookeeper+broker pair is replaced with a single broker+controller node).
- New tests/blocking/json_consumer.rs + json_tests.rs, and header-id integration tests for Avro/JSON/proto against the Java test app's new testavroheader/testjsonheader/testprotoheader topics.
- README.md and RELEASE_NOTES.md document the new API.

See #139.

Make sure there is a related issues, and the docs and unit tests are also updated.

If this changes behaviour described in `schema_registry_converter.allium`, please update the spec too (or note in the PR why it doesn't need it).
