### PR TITLE
Add a method to just register a schema, fixing https://github.com/gkl…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,10 @@ version = "^4.0"
 optional = true
 
 [dev-dependencies]
+# `derive` is only needed for tests/doctests exercising `avro_common::avro_schema_for` via
+# `#[derive(apache_avro::AvroSchema)]` -- unified with the plain `apache-avro` optional
+# dependency (see the `avro` feature) when both are active in the same build.
+apache-avro = { version = "^0.22", features = ["derive"] }
 async-trait = "^0.1"
 criterion = "^0.8"
 http = "^1.0"

--- a/README.md
+++ b/README.md
@@ -229,6 +229,34 @@ See [issue #139](https://github.com/gklijs/schema_registry_converter/issues/139)
 and the docs on `decode_with_header_id`/`encode_with_header_id` for each converter for worked
 examples.
 
+## Deriving an Avro schema from a struct
+
+The `*WithSchema` `SubjectNameStrategy` variants (`RecordNameStrategyWithSchema`, etc.) already
+register a `SuppliedSchema` with the registry if it isn't there yet -- but until now you had to
+hand-write and maintain that schema as a JSON string yourself, kept in sync with the struct by
+hand. `get_supplied_schema_for` closes that gap by building the `SuppliedSchema` straight from
+[`apache-avro`'s own `AvroSchema` trait](https://docs.rs/apache-avro/latest/apache_avro/trait.AvroSchema.html),
+most commonly via `#[derive(apache_avro::AvroSchema)]` (needs apache_avro's `derive` feature):
+
+```rust
+use apache_avro::AvroSchema;
+use serde::Serialize;
+use schema_registry_converter::avro_common::get_supplied_schema_for;
+use schema_registry_converter::schema_registry_common::SubjectNameStrategy;
+
+#[derive(Serialize, AvroSchema)]
+struct Heartbeat {
+    beat: i64,
+}
+
+let strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(get_supplied_schema_for::<Heartbeat>());
+// encoder.encode_struct(Heartbeat { beat: 3 }, &strategy)?;
+```
+
+The registered schema always matches the exact shape apache_avro's own serializer produces for
+the struct, so there's no separate schema to drift out of sync. See
+[issue #111](https://github.com/gklijs/schema_registry_converter/issues/111).
+
 ## Direct interaction with schema registry
 
 Some functions have been opened so this library can be used to directly get all the subjects, all the version of a

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -85,6 +85,14 @@ Not breaking for normal usage, but the exact wording of the `SRCError` returned 
 doesn't match its schema has changed (e.g. `"Failed to resolve"` is now `"Could not get Avro
 bytes"`, with a more specific cause) -- don't match on that text. See #117.
 
+Add `avro_common::get_supplied_schema_for::<T>()`, building a `SuppliedSchema` straight from a type
+implementing apache_avro's own `AvroSchema` trait (most commonly via
+`#[derive(apache_avro::AvroSchema)]`) instead of hand-writing/maintaining the schema as a
+separate JSON string. Combine it with any `*WithSchema` `SubjectNameStrategy` variant, which
+already registers the schema if the registry doesn't have it yet. Purely additive -- a thin
+wrapper around the existing `avro_common::get_supplied_schema`. See #111 and the "Deriving an
+Avro schema from a struct" section of the README.
+
 ### 4.10.0
 
 Propagate properties and tags.

--- a/src/avro_common.rs
+++ b/src/avro_common.rs
@@ -353,6 +353,35 @@ pub fn get_supplied_schema(schema: &Schema) -> SuppliedSchema {
     }
 }
 
+/// Like [`get_supplied_schema`], but for a type implementing `apache_avro`'s own [`AvroSchema`
+/// trait`](apache_avro::AvroSchema) -- most commonly via `#[derive(apache_avro::AvroSchema)]`
+/// (needs apache_avro's `derive` feature) -- instead of an already-built [`Schema`]. Saves
+/// hand-writing and maintaining the schema as a separate JSON string: the registered schema
+/// always matches the exact shape apache_avro's own serializer will produce for `T`, so there's
+/// nothing to drift out of sync with the struct.
+///
+/// Combine it with any of the `*WithSchema`
+/// [`SubjectNameStrategy`](crate::schema_registry_common::SubjectNameStrategy) variants, which
+/// already register the schema with the registry if it isn't there yet:
+/// ```
+/// use apache_avro::AvroSchema;
+/// use serde::Serialize;
+/// use schema_registry_converter::avro_common::get_supplied_schema_for;
+/// use schema_registry_converter::schema_registry_common::SubjectNameStrategy;
+///
+/// #[derive(Serialize, AvroSchema)]
+/// struct Heartbeat {
+///     beat: i64,
+/// }
+///
+/// let strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(get_supplied_schema_for::<Heartbeat>());
+/// ```
+///
+/// See https://github.com/gklijs/schema_registry_converter/issues/111.
+pub fn get_supplied_schema_for<T: apache_avro::AvroSchema>() -> SuppliedSchema {
+    get_supplied_schema(&T::get_schema())
+}
+
 #[cfg(test)]
 mod tests {
     use apache_avro::types::Value;
@@ -361,8 +390,34 @@ mod tests {
 
     use test_utils::{Atype, ConfirmAccountCreation, Heartbeat};
 
-    use crate::avro_common::{values_to_bytes, AvroSchema};
+    use crate::avro_common::{get_name, get_supplied_schema_for, values_to_bytes, AvroSchema};
     use crate::error::SRCError;
+    use crate::schema_registry_common::SchemaType;
+
+    #[test]
+    fn get_supplied_schema_for_matches_derived_schema() {
+        // See https://github.com/gklijs/schema_registry_converter/issues/111.
+        #[derive(serde::Serialize, apache_avro::AvroSchema)]
+        struct SimpleRecord {
+            #[allow(dead_code)]
+            count: i64,
+        }
+
+        let supplied = get_supplied_schema_for::<SimpleRecord>();
+        assert_eq!(supplied.schema_type, SchemaType::Avro);
+        assert!(supplied.references.is_empty());
+        assert!(supplied.properties.is_none());
+        assert!(supplied.tags.is_none());
+
+        // The registered JSON must round-trip into a schema apache_avro itself considers the
+        // same record `SimpleRecord::get_schema()` produces -- otherwise the registered schema
+        // and the data this crate would actually send could disagree.
+        let parsed = Schema::parse_str(&supplied.schema)
+            .expect("get_supplied_schema_for's output must be valid Avro schema JSON");
+        let derived = <SimpleRecord as apache_avro::AvroSchema>::get_schema();
+        assert_eq!(get_name(&parsed), get_name(&derived));
+        assert_eq!(supplied.name, get_name(&derived).map(|n| n.fullname(None)));
+    }
 
     #[test]
     fn to_bytes_no_record() {

--- a/src/blocking/avro.rs
+++ b/src/blocking/avro.rs
@@ -1547,6 +1547,57 @@ mod tests {
     }
 
     #[test]
+    fn test_encode_struct_with_inferred_schema_round_trips() {
+        // See https://github.com/gklijs/schema_registry_converter/issues/111: `get_supplied_schema_for`
+        // lets a caller register+encode using a schema derived from the struct itself (via
+        // `#[derive(apache_avro::AvroSchema)]`), instead of hand-writing/maintaining a separate
+        // JSON schema.
+        #[derive(
+            Debug, PartialEq, serde::Serialize, serde::Deserialize, apache_avro::AvroSchema,
+        )]
+        struct InferredHeartbeat {
+            beat: i64,
+        }
+
+        let supplied = crate::avro_common::get_supplied_schema_for::<InferredHeartbeat>();
+        let subject = supplied.name.clone().expect("derived schema has a name");
+        let schema_json = supplied.schema.clone();
+
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("POST", format!("/subjects/{subject}/versions").as_str())
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(r#"{"id":12}"#)
+            .create();
+        let _m2 = server
+            .mock("GET", "/schemas/ids/12?deleted=true")
+            .with_status(200)
+            .with_header("content-type", "application/vnd.schemaregistry.v1+json")
+            .with_body(format!(
+                r#"{{"schema":{}}}"#,
+                serde_json::to_string(&schema_json).unwrap()
+            ))
+            .create();
+
+        let sr_settings = SrSettings::new_builder(server.url())
+            .no_proxy()
+            .build()
+            .unwrap();
+        let encoder = AvroEncoder::new(sr_settings.clone());
+        let strategy = SubjectNameStrategy::RecordNameStrategyWithSchema(supplied);
+
+        let bytes = encoder
+            .encode_struct(InferredHeartbeat { beat: 42 }, &strategy)
+            .unwrap();
+
+        let decoder = AvroDecoder::new(sr_settings);
+        let value = decoder.decode(Some(&bytes)).unwrap().value;
+        let decoded: InferredHeartbeat = from_value(&value).unwrap();
+        assert_eq!(decoded, InferredHeartbeat { beat: 42 });
+    }
+
+    #[test]
     fn test_encode_record_name_strategy_supplied_record_wrong_response() {
         let mut server = mockito::Server::new();
         let _m = server


### PR DESCRIPTION
…ijs/schema_registry_converter/issues/111.

Make sure there is a related issues, and the docs and unit tests are also updated.

If this changes behaviour described in `schema_registry_converter.allium`, please update the spec too (or note in the PR why it doesn't need it).
